### PR TITLE
Adjusted MVV scale

### DIFF
--- a/src/search_options.h
+++ b/src/search_options.h
@@ -54,7 +54,7 @@ namespace Horsie {
     static i32 QSSeeMargin = 81;
 
     static i32 CheckBonus = 9546;
-    static i32 MVVMult = 14;
+    static i32 MVVMult = 12;
 
     static i32 IIRMinDepth = 3;
     static i32 AspWindow = 12;


### PR DESCRIPTION
```
Elo   | 2.97 +- 2.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 27508 W: 6478 L: 6243 D: 14787
Penta | [46, 3237, 6971, 3436, 64]
```
http://somelizard.pythonanywhere.com/test/2078/