### PR TITLE
Added SMP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PGO = off
 
 EXE := horsie
 
-SOURCES := src/bitboard.cpp src/cuckoo.cpp src/Horsie.cpp src/movegen.cpp src/position.cpp src/precomputed.cpp src/search.cpp src/tt.cpp src/zobrist.cpp src/nnue/nn.cpp src/3rdparty/zstd/zstddeclib.c
+SOURCES := src/bitboard.cpp src/cuckoo.cpp src/Horsie.cpp src/movegen.cpp src/position.cpp src/precomputed.cpp src/search.cpp src/threadpool.cpp src/tt.cpp src/zobrist.cpp src/nnue/nn.cpp src/3rdparty/zstd/zstddeclib.c
 
 COMPILER_VERSION := $(shell $(CXX) --version)
 ARCH_DEFINES := $(shell echo | $(CXX) -march=native -E -dM -)

--- a/src/Horsie.cpp
+++ b/src/Horsie.cpp
@@ -69,7 +69,6 @@ i32 main(i32 argc, char* argv[])
     Precomputed::init();
     Zobrist::init();
     Cuckoo::init();
-    //TT.Initialize(Horsie::Hash);
 
     SearchPool = std::make_unique<SearchThreadPool>(Horsie::Threads);
 
@@ -224,7 +223,6 @@ void HandleSetOptionCommand(std::istringstream& is) {
         i32 hashVal = std::stoi(value);
         if (hashVal >= 1 && hashVal <= TranspositionTable::MaxSize) {
             Horsie::Hash = hashVal;
-            //TT.Initialize(Horsie::Hash);
             SearchPool->TTable.Initialize(Horsie::Hash);
             std::cout << "info string set hash to " << Horsie::Hash << std::endl;
         }

--- a/src/Horsie.cpp
+++ b/src/Horsie.cpp
@@ -308,15 +308,7 @@ void HandleGoCommand(Position& pos, std::istringstream& is) {
 
     SearchLimits limits = ParseGoParameters(pos, is);
 
-    if (!limits.HasMoveTime() && limits.HasPlayerTime()) {
-        thread->MakeMoveTime(limits);
-    }
-    else if (limits.HasMoveTime()) {
-        limits.MaxSearchTime = limits.MoveTime;
-    }
-    else {
-        limits.MaxSearchTime = INT32_MAX;
-    }
+    thread->SoftTimeLimit = limits.SetTimeLimits();
 
     SearchPool->StartSearch(pos, limits);
 }
@@ -351,7 +343,7 @@ void HandleEvalCommand(Position& pos) {
 
 
 void HandleStopCommand() {
-    SearchPool->StopThreads.store(true, std::memory_order_relaxed);
+    SearchPool->SetStop();
 }
 
 

--- a/src/search.h
+++ b/src/search.h
@@ -18,11 +18,6 @@
 
 namespace Horsie {
 
-    static const i32 DepthQChecks = 0;
-    static const i32 DepthQNoChecks = -1;
-
-    static const i32 SEARCH_TIME_BUFFER = 25;
-
     enum SearchNodeType {
         PVNode,
         NonPVNode,
@@ -50,6 +45,24 @@ namespace Horsie {
             const bool HasPlayerTime() const { return PlayerTime != 0; }
 
             const bool IsInfinite() const { return MaxDepth == Horsie::MaxDepth && MaxSearchTime == INT32_MAX; }
+
+            const i32 SetTimeLimits() {
+                i32 softLimit = 0;
+
+                if (HasMoveTime()) {
+                    MaxSearchTime = MoveTime;
+                }
+                else if (HasPlayerTime()) {
+                    MaxSearchTime = Increment + (PlayerTime / std::min(MovesToGo, 2));
+                    MaxSearchTime = std::min(MaxSearchTime, PlayerTime);
+                    softLimit = static_cast<i32>(0.65 * ((static_cast<double>(PlayerTime) / MovesToGo) + (Increment * 3 / 4.0)));
+                }
+                else {
+                    MaxSearchTime = INT32_MAX;
+                }
+
+                return softLimit;
+            }
 
             void PrintLimits() const {
 				std::cout << "MaxDepth:      " << MaxDepth << std::endl;

--- a/src/search.h
+++ b/src/search.h
@@ -49,6 +49,8 @@ namespace Horsie {
             i32 PlayerTime = 0;
             const bool HasPlayerTime() const { return PlayerTime != 0; }
 
+            const bool IsInfinite() const { return MaxDepth == Horsie::MaxDepth && MaxSearchTime == INT32_MAX; }
+
             void PrintLimits() const {
 				std::cout << "MaxDepth:      " << MaxDepth << std::endl;
 				std::cout << "MaxNodes:      " << MaxNodes << std::endl;
@@ -116,100 +118,19 @@ namespace Horsie {
             std::vector<Horsie::Move> PV;
         };
 
+        struct ThreadSetup {
+            std::string StartFEN;
+            std::vector<Move> SetupMoves;
+            std::vector<Move> UCISearchMoves;
 
+            ThreadSetup(std::vector<Move> setupMoves) : ThreadSetup(InitialFEN, setupMoves, {}) {}
+            ThreadSetup(std::string_view fen = InitialFEN) : ThreadSetup(fen, {}, {}) {}
 
-        class SearchThread
-        {
-        public:
-            u64 Nodes;
-            i32 NMPPly;
-            i32 ThreadIdx;
-            i32 PVIndex;
-            i32 RootDepth;
-            i32 SelDepth;
-            i32 CompletedDepth;
-            i32 CheckupCount = 0;
-            bool Searching;
-            bool Quit;
-            bool IsMain = false;
-
-            std::chrono::system_clock::time_point TimeStart = std::chrono::system_clock::now();
-            i32 SearchTimeMS = 0;
-            u64 MaxNodes = 0;
-            bool StopSearching = false;
-
-            std::function<void()> OnDepthFinish;
-            std::vector<RootMove> RootMoves{};
-            HistoryTable History{};
-
-            bool HasSoftTime = false;
-            i32 SoftTimeLimit = 0;
-            Util::NDArray<u64, 64, 64> NodeTable{};
-
-            Move CurrentMove() const { return RootMoves[PVIndex].move; }
-
-
-            void Search(Position& pos, SearchLimits& info);
-
-            template <SearchNodeType NodeType>
-            i32 Negamax(Position& pos, SearchStackEntry* ss, i32 alpha, i32 beta, i32 depth, bool cutNode);
-
-            template <SearchNodeType NodeType>
-            i32 QSearch(Position& pos, SearchStackEntry* ss, i32 alpha, i32 beta);
-
-            void UpdateCorrectionHistory(Position& pos, i32 diff, i32 depth);
-            i16 AdjustEval(Position& pos, i32 us, i16 rawEval);
-
-            inline i32 GetRFPMargin(i32 depth, bool improving) const { return (depth - (improving)) * RFPMargin; }
-            inline i32 StatBonus(i32 depth) const { return std::min((StatBonusMult * depth) - StatBonusSub, StatBonusMax); }
-            inline i32 StatMalus(i32 depth) const { return std::min((StatMalusMult * depth) - StatMalusSub, StatMalusMax); }
-
-            void AssignProbCutScores(Position& pos, ScoredMove* list, i32 size);
-            void AssignQuiescenceScores(Position& pos, SearchStackEntry* ss, HistoryTable& history, ScoredMove* list, i32 size, Move ttMove);
-            void AssignScores(Position& pos, SearchStackEntry* ss, HistoryTable& history, ScoredMove* list, i32 size, Move ttMove);
-            Move OrderNextMove(ScoredMove* moves, i32 size, i32 listIndex);
-
-            void UpdatePV(Move* pv, Move move, Move* childPV);
-
-            void UpdateContinuations(SearchStackEntry* ss, i32 pc, i32 pt, i32 sq, i32 bonus);
-            void UpdateStats(Position& pos, SearchStackEntry* ss, Move bestMove, i32 bestScore, i32 beta, i32 depth, Move* quietMoves, i32 quietCount, Move* captureMoves, i32 captureCount);
-
-            std::string Debug_GetMovesPlayed(SearchStackEntry* ss);
-
-
-
-            i64 GetSearchTime() const {
-                auto now = std::chrono::system_clock::now();
-                auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - TimeStart);
-                return duration.count();
+            ThreadSetup(std::string_view fen, std::vector<Move> setupMoves, std::vector<Move> uciSearchMoves) {
+                StartFEN = fen;
+                SetupMoves = setupMoves;
+                UCISearchMoves = uciSearchMoves;
             }
-
-            bool CheckTime() const {
-                const auto time = GetSearchTime();
-                return (time > SearchTimeMS - SEARCH_TIME_BUFFER);
-            }
-
-            void MakeMoveTime(SearchLimits& limits) {
-                i32 newSearchTime = limits.Increment + std::max(limits.PlayerTime / 2, limits.PlayerTime / limits.MovesToGo);
-
-                newSearchTime = std::min(newSearchTime, limits.PlayerTime);
-
-                //  Values from Clarity
-                SoftTimeLimit = static_cast<i32>(0.65 * ((static_cast<double>(limits.PlayerTime) / limits.MovesToGo) + (limits.Increment * 3 / 4.0)));
-                HasSoftTime = true;
-
-                limits.MaxSearchTime = newSearchTime;
-            }
-
-            void Reset() {
-                Nodes = 0;
-                PVIndex = RootDepth = SelDepth = CompletedDepth = CheckupCount = NMPPly = 0;
-                SoftTimeLimit = 0;
-                HasSoftTime = StopSearching = false;
-            }
-
-        private:
-            const i32 CheckupMax = 512;
         };
 
 

--- a/src/search_bench.h
+++ b/src/search_bench.h
@@ -26,6 +26,9 @@ namespace Horsie {
 
         Position pos = Position(InitialFEN);
         SearchThread* thread = SearchPool.MainThread();
+
+        auto odf = thread->OnDepthFinish;
+        auto osf = thread->OnSearchFinish;
         thread->OnDepthFinish = []() {};
         thread->OnSearchFinish = []() {};
 
@@ -44,7 +47,7 @@ namespace Horsie {
             pos.LoadFromFEN(fen);
             //thread.Search(pos, limits);
             SearchPool.StartSearch(pos, limits);
-            SearchPool.MainThreadBase()->WaitForThreadFinished();
+            SearchPool.WaitForMain();
 
             u64 thisNodeCount = SearchPool.GetNodeCount();
             totalNodes += thisNodeCount;
@@ -72,6 +75,9 @@ namespace Horsie {
         else {
             std::cout << std::endl << "Nodes searched: " << totalNodes << " in " << durSeconds << "." << durMillis << " s (" << FormatWithCommas(nps) << " nps)" << std::endl;
         }
+
+        thread->OnDepthFinish = odf;
+        thread->OnSearchFinish = osf;
     }
 
 }

--- a/src/search_bench.h
+++ b/src/search_bench.h
@@ -45,7 +45,7 @@ namespace Horsie {
         for (std::string fen : BenchFENs)
         {
             pos.LoadFromFEN(fen);
-            //thread.Search(pos, limits);
+
             SearchPool.StartSearch(pos, limits);
             SearchPool.WaitForMain();
 

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -11,6 +11,7 @@ namespace Horsie {
 
     static i32 Hash = 32;
 
+    static i32 MoveOverhead = 25;
     static bool UCI_Chess960 = false;
 
     const bool ShallowPruning = true;

--- a/src/threadpool.cpp
+++ b/src/threadpool.cpp
@@ -1,0 +1,170 @@
+
+
+#include "threadpool.h"
+#include "movegen.h"
+
+namespace Horsie {
+
+	void SearchThreadPool::Resize(int newThreadCount) {
+
+		if (Threads.size() > 0) {
+			MainThreadBase()->WaitForThreadFinished();
+
+			while (Threads.size() > 0)
+				delete Threads.back(), Threads.pop_back();
+		}
+
+		//Threads.clear();
+		//Threads.resize(newThreadCount);
+		
+		for (i32 i = 0; i < newThreadCount; i++) {
+			auto td = new Thread(i);
+			auto worker = td->worker.get();
+			worker->ThreadIdx = i;
+			worker->AssocPool = this;
+			worker->TT = &TTable;
+			Threads.push_back(td);
+		}
+
+		MainThreadBase()->WaitForThreadFinished();
+	}
+
+	void SearchThreadPool::StartSearch(Position& rootPosition, const SearchLimits& rootInfo) {
+		ThreadSetup setup{};
+		StartSearch(rootPosition, rootInfo, setup);
+	}
+
+	void SearchThreadPool::StartSearch(Position& rootPosition, const SearchLimits& rootInfo, ThreadSetup& setup) {
+		MainThreadBase()->WaitForThreadFinished();
+		MainThread()->StartTime = std::chrono::system_clock::now();
+
+		StopThreads.store(false, std::memory_order::seq_cst);
+		SharedInfo = rootInfo;          //  Initialize the shared SearchInformation
+		//SharedInfo.SearchActive = true;
+
+		auto& rootFEN = setup.StartFEN;
+		if (rootFEN == InitialFEN && setup.SetupMoves.size() == 0) {
+			rootFEN = rootPosition.GetFEN();
+		}
+
+		ScoredMove rms[MoveListSize] = {};
+		i32 size = Generate<GenLegal>(rootPosition, &rms[0], 0);
+
+		for (auto t : Threads) {
+			auto td = t->worker.get();
+			td->Reset();
+
+			td->RootMoves.clear();
+			td->RootMoves.shrink_to_fit();
+			td->RootMoves.reserve(size);
+			for (int j = 0; j < size; j++) {
+				td->RootMoves.push_back(RootMove(rms[j].move));
+			}
+
+			if (setup.UCISearchMoves.size() != 0) {
+				//td.RootMoves = td.RootMoves.Where(x => setup.UCISearchMoves.Contains(x.Move)).ToList();
+			}
+
+			td->RootPosition.LoadFromFEN(rootFEN);
+
+			for(auto& move : setup.SetupMoves) {
+				td->RootPosition.MakeMove(move);
+			}
+		}
+
+		//SharedInfo.TimeManager.StartTimer();
+		MainThreadBase()->start_searching();
+	}
+
+	SearchThread* SearchThreadPool::GetBestThread() const {
+		return MainThread();
+	}
+
+	void SearchThreadPool::StartThreads() const {
+		for (i32 i = 1; i < Threads.size(); i++) {
+			Threads[i]->start_searching();
+		}
+	}
+
+	void SearchThreadPool::WaitForSearchFinished() const {
+		for (i32 i = 1; i < Threads.size(); i++) {
+			Threads[i]->WaitForThreadFinished();
+		}
+	}
+
+	void SearchThreadPool::BlockCallerUntilFinished() {
+		Blocker.arrive_and_wait();
+	}
+
+	void SearchThreadPool::Clear() const {
+		for (i32 i = 0; i < Threads.size(); i++) {
+			Threads[i]->worker.get()->History.Clear();
+		}
+
+		MainThread()->CheckupCount = 0;
+	}
+
+
+
+	Thread::Thread(i32 n) {
+		idx = n;
+		worker = std::make_unique<SearchThread>();
+		stdThread = std::thread(&Thread::idle_loop, this);
+	}
+
+
+	// Destructor wakes up the thread in idle_loop() and waits
+	// for its termination. Thread should be already waiting.
+	Thread::~Thread() {
+
+		assert(!searching);
+
+		exit = true;
+		start_searching();
+		stdThread.join();
+	}
+
+
+	// Wakes up the thread that will start the search
+	void Thread::start_searching() {
+		mutex.lock();
+		searching = true;
+		mutex.unlock();   // Unlock before notifying saves a few CPU-cycles
+		cv.notify_one();  // Wake up the thread in idle_loop()
+	}
+
+
+	// Blocks on the condition variable
+	// until the thread has finished searching.
+	void Thread::WaitForThreadFinished() {
+
+		std::unique_lock<std::mutex> lk(mutex);
+		cv.wait(lk, [&] { return !searching; });
+	}
+
+
+	// Thread gets parked here, blocked on the
+	// condition variable, when it has no work to do.
+
+	void Thread::idle_loop() {
+		while (true) {
+			std::unique_lock<std::mutex> lk(mutex);
+			searching = false;
+			cv.notify_one();  // Wake up anyone waiting for search finished
+			cv.wait(lk, [&] { return searching; });
+
+			if (exit)
+				return;
+
+			lk.unlock();
+
+			//worker->start_searching();
+			if (worker->IsMain()) {
+				worker->MainThreadSearch();
+			}
+			else {
+				worker->Search(worker->AssocPool->SharedInfo);
+			}
+		}
+	}
+}

--- a/src/threadpool.h
+++ b/src/threadpool.h
@@ -37,15 +37,12 @@ namespace Horsie {
         void   idle_loop();
         void   start_searching();
         void   WaitForThreadFinished();
-        size_t id() const { return idx; }
 
         std::unique_ptr<SearchThread> worker;
 
     private:
         std::mutex mutex;
         std::condition_variable cv;
-        size_t idx;
-        size_t nthreads;
         bool exit = false;
         bool searching = true;
         std::thread stdThread;
@@ -62,28 +59,25 @@ namespace Horsie {
         i32 SelDepth{};
         i32 CompletedDepth{};
         i32 CheckupCount{};
-        bool Searching{};
-        bool Quit{};
-        constexpr bool IsMain() const { return ThreadIdx == 0; }
-        SearchThreadPool* AssocPool;
-        TranspositionTable* TT;
+
+        i32 HardTimeLimit{};
+        i32 SoftTimeLimit{};
+        u64 HardNodeLimit{};
+
+        SearchThreadPool* AssocPool{};
+        TranspositionTable* TT{};
+        Position RootPosition;
+        HistoryTable History{};
+        Util::NDArray<u64, 64, 64> NodeTable{};
 
         std::chrono::system_clock::time_point StartTime{};
-        i32 TimeLimit{};
-        u64 MaxNodes{};
 
         std::function<void()> OnDepthFinish;
         std::function<void()> OnSearchFinish;
         std::vector<RootMove> RootMoves{};
-        Position RootPosition;
-        HistoryTable History{};
 
-        i32 SoftTimeLimit{};
-        Util::NDArray<u64, 64, 64> NodeTable{};
-
-        //SearchThread(i32 idx = 0) : ThreadIdx(idx) {
-
-        //}
+        constexpr bool HasSoftTime() const { return SoftTimeLimit != 0; }
+        constexpr bool IsMain() const { return ThreadIdx == 0; }
 
         void MainThreadSearch();
 
@@ -96,20 +90,21 @@ namespace Horsie {
         i32 QSearch(Position& pos, SearchStackEntry* ss, i32 alpha, i32 beta);
 
         void UpdateCorrectionHistory(Position& pos, i32 diff, i32 depth);
-        i16 AdjustEval(Position& pos, i32 us, i16 rawEval);
+        i16 AdjustEval(Position& pos, i32 us, i16 rawEval) const;
 
-        void AssignProbCutScores(Position& pos, ScoredMove* list, i32 size);
-        void AssignQuiescenceScores(Position& pos, SearchStackEntry* ss, HistoryTable& history, ScoredMove* list, i32 size, Move ttMove);
-        void AssignScores(Position& pos, SearchStackEntry* ss, HistoryTable& history, ScoredMove* list, i32 size, Move ttMove);
-        Move OrderNextMove(ScoredMove* moves, i32 size, i32 listIndex);
+        void AssignProbCutScores(Position& pos, ScoredMove* list, i32 size) const;
+        void AssignQuiescenceScores(Position& pos, SearchStackEntry* ss, HistoryTable& history, ScoredMove* list, i32 size, Move ttMove) const;
+        void AssignScores(Position& pos, SearchStackEntry* ss, HistoryTable& history, ScoredMove* list, i32 size, Move ttMove) const;
+        Move OrderNextMove(ScoredMove* moves, i32 size, i32 listIndex) const;
 
-        void UpdatePV(Move* pv, Move move, Move* childPV);
+        void UpdatePV(Move* pv, Move move, Move* childPV) const;
 
-        void UpdateContinuations(SearchStackEntry* ss, i32 pc, i32 pt, i32 sq, i32 bonus);
+        void UpdateContinuations(SearchStackEntry* ss, i32 pc, i32 pt, i32 sq, i32 bonus) const;
         void UpdateStats(Position& pos, SearchStackEntry* ss, Move bestMove, i32 bestScore, i32 beta, i32 depth, Move* quietMoves, i32 quietCount, Move* captureMoves, i32 captureCount);
 
-        std::string Debug_GetMovesPlayed(SearchStackEntry* ss);
+        std::string Debug_GetMovesPlayed(SearchStackEntry* ss) const;
 
+        void PrintSearchInfo() const;
 
 
         i64 GetSearchTime() const {
@@ -118,21 +113,13 @@ namespace Horsie {
             return duration.count();
         }
 
-        void MakeMoveTime(SearchLimits& limits) {
-            limits.MaxSearchTime = std::min(limits.Increment + std::max(limits.PlayerTime / 2, limits.PlayerTime / limits.MovesToGo), limits.PlayerTime);
-
-            //  Values from Clarity
-            SoftTimeLimit = static_cast<i32>(0.65 * ((static_cast<double>(limits.PlayerTime) / limits.MovesToGo) + (limits.Increment * 3 / 4.0)));
-        }
-
         void Reset() {
             Nodes = 0;
             PVIndex = RootDepth = SelDepth = CompletedDepth = CheckupCount = NMPPly = 0;
         }
 
-        constexpr bool HasSoftTime() const { return SoftTimeLimit != 0; }
         Move CurrentMove() const { return RootMoves[PVIndex].move; }
-        bool CheckTime() const { return (GetSearchTime() > TimeLimit - SEARCH_TIME_BUFFER); }
+        bool HardTimeReached() const { return (GetSearchTime() > HardTimeLimit - MoveOverhead); }
 
         inline i32 GetRFPMargin(i32 depth, bool improving) const { return (depth - (improving)) * RFPMargin; }
         inline i32 StatBonus(i32 depth) const { return std::min((StatBonusMult * depth) - StatBonusSub, StatBonusMax); }
@@ -149,7 +136,6 @@ namespace Horsie {
 		std::vector<Thread*> Threads;
         TranspositionTable TTable;
         std::atomic_bool StopThreads{};
-        std::barrier<> Blocker{ 2 };
 
         SearchThreadPool(i32 n = 1) {
             TTable.Initialize(Horsie::Hash);
@@ -159,13 +145,16 @@ namespace Horsie {
         constexpr SearchThread* MainThread() const { return Threads.front()->worker.get(); }
         constexpr Thread* MainThreadBase() const { return Threads.front(); }
 
+        void SetStop() { StopThreads = true; }
+
         void Resize(int newThreadCount);
         void StartSearch(Position& rootPosition, const SearchLimits& rootInfo);
         void StartSearch(Position& rootPosition, const SearchLimits& rootInfo, ThreadSetup& setup);
+        void WaitForMain() const;
         SearchThread* GetBestThread() const;
+        void SendBestMove() const;
         void StartThreads() const;
         void WaitForSearchFinished() const;
-        void BlockCallerUntilFinished();
         void Clear() const;
 
         u64 GetNodeCount() const {

--- a/src/threadpool.h
+++ b/src/threadpool.h
@@ -1,0 +1,184 @@
+#pragma once
+
+#ifndef THREADPOOL_H
+#define THREADPOOL_H
+
+#include <thread>
+#include <barrier>
+
+#include <array>
+#include <vector>
+#include <chrono>
+#include <algorithm>
+#include <functional>
+#include <mutex>
+
+#include "tt.h"
+#include "move.h"
+#include "history.h"
+#include "search.h"
+#include "position.h"
+#include "util/alloc.h"
+#include "search_options.h"
+
+using namespace Horsie::Util::ThingsIStoleFromStormphrax;
+using namespace Horsie::Search;
+
+namespace Horsie {
+
+    class SearchThreadPool;
+    class SearchThread;
+
+    class Thread {
+    public:
+        Thread(i32 n);
+        virtual ~Thread();
+
+        void   idle_loop();
+        void   start_searching();
+        void   WaitForThreadFinished();
+        size_t id() const { return idx; }
+
+        std::unique_ptr<SearchThread> worker;
+
+    private:
+        std::mutex mutex;
+        std::condition_variable cv;
+        size_t idx;
+        size_t nthreads;
+        bool exit = false;
+        bool searching = true;
+        std::thread stdThread;
+    };
+
+
+    class SearchThread {
+    public:
+        u64 Nodes{};
+        i32 NMPPly{};
+        i32 ThreadIdx{};
+        i32 PVIndex{};
+        i32 RootDepth{};
+        i32 SelDepth{};
+        i32 CompletedDepth{};
+        i32 CheckupCount{};
+        bool Searching{};
+        bool Quit{};
+        constexpr bool IsMain() const { return ThreadIdx == 0; }
+        SearchThreadPool* AssocPool;
+        TranspositionTable* TT;
+
+        std::chrono::system_clock::time_point StartTime{};
+        i32 TimeLimit{};
+        u64 MaxNodes{};
+
+        std::function<void()> OnDepthFinish;
+        std::function<void()> OnSearchFinish;
+        std::vector<RootMove> RootMoves{};
+        Position RootPosition;
+        HistoryTable History{};
+
+        i32 SoftTimeLimit{};
+        Util::NDArray<u64, 64, 64> NodeTable{};
+
+        //SearchThread(i32 idx = 0) : ThreadIdx(idx) {
+
+        //}
+
+        void MainThreadSearch();
+
+        void Search(SearchLimits& info);
+
+        template <SearchNodeType NodeType>
+        i32 Negamax(Position& pos, SearchStackEntry* ss, i32 alpha, i32 beta, i32 depth, bool cutNode);
+
+        template <SearchNodeType NodeType>
+        i32 QSearch(Position& pos, SearchStackEntry* ss, i32 alpha, i32 beta);
+
+        void UpdateCorrectionHistory(Position& pos, i32 diff, i32 depth);
+        i16 AdjustEval(Position& pos, i32 us, i16 rawEval);
+
+        void AssignProbCutScores(Position& pos, ScoredMove* list, i32 size);
+        void AssignQuiescenceScores(Position& pos, SearchStackEntry* ss, HistoryTable& history, ScoredMove* list, i32 size, Move ttMove);
+        void AssignScores(Position& pos, SearchStackEntry* ss, HistoryTable& history, ScoredMove* list, i32 size, Move ttMove);
+        Move OrderNextMove(ScoredMove* moves, i32 size, i32 listIndex);
+
+        void UpdatePV(Move* pv, Move move, Move* childPV);
+
+        void UpdateContinuations(SearchStackEntry* ss, i32 pc, i32 pt, i32 sq, i32 bonus);
+        void UpdateStats(Position& pos, SearchStackEntry* ss, Move bestMove, i32 bestScore, i32 beta, i32 depth, Move* quietMoves, i32 quietCount, Move* captureMoves, i32 captureCount);
+
+        std::string Debug_GetMovesPlayed(SearchStackEntry* ss);
+
+
+
+        i64 GetSearchTime() const {
+            auto now = std::chrono::system_clock::now();
+            auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - StartTime);
+            return duration.count();
+        }
+
+        void MakeMoveTime(SearchLimits& limits) {
+            limits.MaxSearchTime = std::min(limits.Increment + std::max(limits.PlayerTime / 2, limits.PlayerTime / limits.MovesToGo), limits.PlayerTime);
+
+            //  Values from Clarity
+            SoftTimeLimit = static_cast<i32>(0.65 * ((static_cast<double>(limits.PlayerTime) / limits.MovesToGo) + (limits.Increment * 3 / 4.0)));
+        }
+
+        void Reset() {
+            Nodes = 0;
+            PVIndex = RootDepth = SelDepth = CompletedDepth = CheckupCount = NMPPly = SoftTimeLimit = 0;
+        }
+
+        constexpr bool HasSoftTime() const { return SoftTimeLimit != 0; }
+        Move CurrentMove() const { return RootMoves[PVIndex].move; }
+        bool CheckTime() const { return (GetSearchTime() > TimeLimit - SEARCH_TIME_BUFFER); }
+
+        inline i32 GetRFPMargin(i32 depth, bool improving) const { return (depth - (improving)) * RFPMargin; }
+        inline i32 StatBonus(i32 depth) const { return std::min((StatBonusMult * depth) - StatBonusSub, StatBonusMax); }
+        inline i32 StatMalus(i32 depth) const { return std::min((StatMalusMult * depth) - StatMalusSub, StatMalusMax); }
+
+    private:
+        const i32 CheckupMax = 512;
+    };
+
+
+	class SearchThreadPool {
+	public:
+        SearchLimits SharedInfo;
+		std::vector<Thread*> Threads;
+        TranspositionTable TTable;
+        std::atomic_bool StopThreads{};
+        std::barrier<> Blocker{ 2 };
+
+        SearchThreadPool(i32 n = 1) {
+            TTable.Initialize(Horsie::Hash);
+            Resize(n);
+        }
+
+        constexpr SearchThread* MainThread() const { return Threads.front()->worker.get(); }
+        constexpr Thread* MainThreadBase() const { return Threads.front(); }
+
+        void Resize(int newThreadCount);
+        void StartSearch(Position& rootPosition, const SearchLimits& rootInfo);
+        void StartSearch(Position& rootPosition, const SearchLimits& rootInfo, ThreadSetup& setup);
+        SearchThread* GetBestThread() const;
+        void StartThreads() const;
+        void WaitForSearchFinished() const;
+        void BlockCallerUntilFinished();
+        void Clear() const;
+
+        u64 GetNodeCount() const {
+            u64 sum = 0;
+            for (auto& td : Threads) {
+                sum += td->worker.get()->Nodes;
+            }
+            return sum;
+        }
+
+        static const i32 MaxThreads = 512;
+	};
+
+}
+
+#endif // !THREADPOOL_H

--- a/src/threadpool.h
+++ b/src/threadpool.h
@@ -127,7 +127,7 @@ namespace Horsie {
 
         void Reset() {
             Nodes = 0;
-            PVIndex = RootDepth = SelDepth = CompletedDepth = CheckupCount = NMPPly = SoftTimeLimit = 0;
+            PVIndex = RootDepth = SelDepth = CompletedDepth = CheckupCount = NMPPly = 0;
         }
 
         constexpr bool HasSoftTime() const { return SoftTimeLimit != 0; }

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -3,7 +3,7 @@
 
 namespace Horsie {
 
-    TranspositionTable TT;
+    //TranspositionTable TT;
 
     bool TranspositionTable::Probe(u64 hash, TTEntry*& tte) const
     {
@@ -58,7 +58,7 @@ namespace Horsie {
         std::memset(Clusters, 0, sizeof(TTCluster) * size);
     }
 
-    void TTEntry::Update(u64 key, i16 score, TTNodeType nodeType, i32 depth, Move move, i16 statEval, bool isPV) {
+    void TTEntry::Update(u64 key, i16 score, TTNodeType nodeType, i32 depth, Move move, i16 statEval, u8 age, bool isPV) {
 
         u16 k = static_cast<u16>(key);
 
@@ -75,7 +75,7 @@ namespace Horsie {
             SetScore(score);
             SetStatEval(statEval);
             _depth = static_cast<u8>(depth - DepthOffset);
-            _AgePVType = static_cast<u8>(TT.Age | ((isPV ? 1 : 0) << 2) | static_cast<u32>(nodeType));
+            _AgePVType = static_cast<u8>(age | ((isPV ? 1 : 0) << 2) | static_cast<u32>(nodeType));
         }
     }
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -3,8 +3,6 @@
 
 namespace Horsie {
 
-    //TranspositionTable TT;
-
     bool TranspositionTable::Probe(u64 hash, TTEntry*& tte) const
     {
         TTCluster* const cluster = GetCluster(hash);

--- a/src/tt.h
+++ b/src/tt.h
@@ -72,7 +72,7 @@ namespace Horsie {
 
         constexpr i8 RelAge(u8 age) const { return static_cast<i8>((TT_AGE_CYCLE + age - _AgePVType) & TT_AGE_MASK); }
 
-        void Update(u64 key, i16 score, TTNodeType nodeType, i32 depth, Move move, i16 statEval, bool isPV = false);
+        void Update(u64 key, i16 score, TTNodeType nodeType, i32 depth, Move move, i16 statEval, u8 age, bool isPV = false);
 
         static constexpr i32 DepthNone = -6;
 
@@ -114,14 +114,14 @@ namespace Horsie {
         }
 
         TTCluster* Clusters = nullptr;
-        u16 Age = 0;
+        u8 Age = 0;
         u64 ClusterCount = 0;
 
         static const i32 DefaultTTSize = 32;
         static const i32 MaxSize = 1048576;
     };
 
-    extern TranspositionTable TT;
+    //extern TranspositionTable TT;
 
 }
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -46,12 +46,12 @@ namespace Horsie {
 
 
     struct TTEntry {
-        i16 _Score;           //  16 bits
-        i16 _StatEval;		//  16 bits
-        Move BestMove;          //  16 bits
-        u16 Key;             //  16 bits
-        u8 _AgePVType;        //  5 + 2 + 1 bits
-        u8 _depth;            //  8 bits
+        i16 _Score;     //  16 bits
+        i16 _StatEval;  //  16 bits
+        Move BestMove;  //  16 bits
+        u16 Key;        //  16 bits
+        u8 _AgePVType;  //  5 + 2 + 1 bits
+        u8 _depth;      //  8 bits
 
 
         constexpr i16 Score() const { return _Score; }
@@ -120,8 +120,6 @@ namespace Horsie {
         static const i32 DefaultTTSize = 32;
         static const i32 MaxSize = 1048576;
     };
-
-    //extern TranspositionTable TT;
 
 }
 


### PR DESCRIPTION
Thread scaling seems on par with Lizard (and other SMP engines)

```
Elo   | 81.18 +- 10.17 (95%)
SPRT  | 8.0+0.08s Threads=2 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 1024 W: 342 L: 107 D: 575
Penta | [0, 35, 212, 260, 5]
```
https://somelizard.pythonanywhere.com/test/2107/

```
Elo   | 139.90 +- 9.25 (95%)
Conf  | 8.0+0.08s Threads=4 Hash=32MB
Games | N: 1002 W: 431 L: 48 D: 523
Penta | [0, 6, 121, 359, 15]
```
https://somelizard.pythonanywhere.com/test/2108/