### PR TITLE
Remove probcut depth limit

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -410,7 +410,6 @@ namespace Horsie {
         if (UseProbcut
             && !isPV
             && !doSkip
-            && depth >= ProbcutMinDepth
             && std::abs(beta) < ScoreTTWin
             && (!ss->TTHit || tte->Depth() < depth - 3 || tte->Score() >= probBeta))
         {

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -40,7 +40,7 @@ namespace Horsie {
     UCI_OPTION(RFPMaxDepth, 6)
     UCI_OPTION(RFPMargin, 47)
 
-    UCI_OPTION_CUSTOM(ProbcutMinDepth, 1, 1, 5)
+    //UCI_OPTION_CUSTOM(ProbcutMinDepth, 1, 1, 5)
     UCI_OPTION(ProbcutBeta, 256)
     UCI_OPTION(ProbcutBetaImp, 101)
 

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -40,7 +40,7 @@ namespace Horsie {
     UCI_OPTION(RFPMaxDepth, 6)
     UCI_OPTION(RFPMargin, 47)
 
-    UCI_OPTION_CUSTOM(ProbcutMinDepth, 2, 1, 5)
+    UCI_OPTION_CUSTOM(ProbcutMinDepth, 1, 1, 5)
     UCI_OPTION(ProbcutBeta, 256)
     UCI_OPTION(ProbcutBetaImp, 101)
 


### PR DESCRIPTION
```
Elo   | 0.61 +- 2.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 18934 W: 4210 L: 4177 D: 10547
Penta | [27, 2200, 4978, 2237, 25]
```
https://somelizard.pythonanywhere.com/test/2214/

```
Elo   | -0.30 +- 3.19 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.81 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 10402 W: 2313 L: 2322 D: 5767
Penta | [0, 1192, 2828, 1179, 2]
```
https://somelizard.pythonanywhere.com/test/2217/