### PR TITLE
QSearch TTPV fix

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -940,7 +940,7 @@ namespace Horsie {
 
         TTNodeType bound = (bestScore >= beta) ? TTNodeType::Alpha : TTNodeType::Beta;
 
-        tte->Update(pos.Hash(), MakeTTScore(static_cast<i16>(bestScore), ss->Ply), bound, 0, bestMove, rawEval, TT->Age, ss->TTPV);
+        tte->Update(pos.Hash(), MakeTTScore(static_cast<i16>(bestScore), ss->Ply), bound, 0, bestMove, rawEval, TT->Age, ttPV);
 
         return bestScore;
     }

--- a/src/types.h
+++ b/src/types.h
@@ -35,7 +35,7 @@
 namespace Horsie {
 
     constexpr auto InitialFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-    constexpr auto EngVersion = "1.0.3";
+    constexpr auto EngVersion = "1.0.4";
 
 constexpr u64 FileABB = 0x0101010101010101ULL;
 constexpr u64 FileBBB = FileABB << 1;


### PR DESCRIPTION
Treating this as a bugfix that would've passed non-reg instead of a gainer.
```
Elo   | 1.46 +- 2.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | 1.02 (-2.25, 2.89) [0.00, 3.00]
Games | N: 28268 W: 6369 L: 6250 D: 15649
Penta | [33, 3289, 7374, 3402, 36]
```
https://somelizard.pythonanywhere.com/test/2229/

```
Elo   | 0.84 +- 2.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 0.11 (-2.25, 2.89) [0.00, 3.00]
Games | N: 24302 W: 5446 L: 5387 D: 13469
Penta | [31, 2897, 6243, 2942, 38]
```
https://somelizard.pythonanywhere.com/test/2222/