### PR TITLE
Added futility pruning in negamax

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -533,7 +533,7 @@ namespace Horsie {
                 i32 lmrDepth = std::max(0, depth - lmrRed);
 
                 i32 lmrMargin = 200 + (lmrDepth * 80) + (moveHist / 150);
-                if (isQuiet && !ss->InCheck && eval + lmrMargin < alpha) {
+                if (isQuiet && lmrDepth <= 8 && !ss->InCheck && ss->StaticEval + lmrMargin < alpha) {
                     skipQuiets = true;
                     continue;
                 }

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -44,6 +44,13 @@ namespace Horsie {
     UCI_OPTION(ProbcutBeta, 256)
     UCI_OPTION(ProbcutBetaImp, 101)
 
+    UCI_OPTION(NMFutileBase, 512)
+    UCI_OPTION(NMFutilePVCoeff, 1024)
+    UCI_OPTION(NMFutileImpCoeff, 1024)
+    UCI_OPTION(NMFutileHistCoeff, 1024)
+    UCI_OPTION(NMFutMarginB, 200)
+    UCI_OPTION(NMFutMarginM, 80)
+    UCI_OPTION(NMFutMarginDiv, 150)
     UCI_OPTION(ShallowSEEMargin, 216)
     UCI_OPTION(ShallowMaxDepth, 9)
 
@@ -68,11 +75,11 @@ namespace Horsie {
     UCI_OPTION(StatMalusSub, 111)
     UCI_OPTION(StatMalusMax, 1663)
 
-    UCI_OPTION(SEEValue_Pawn, 105)
-    UCI_OPTION(SEEValue_Horsie, 900)
-    UCI_OPTION(SEEValue_Bishop, 1054)
-    UCI_OPTION(SEEValue_Rook, 1332);
-    UCI_OPTION(SEEValue_Queen, 2300);
+    UCI_OPTION(SEEValuePawn, 105)
+    UCI_OPTION(SEEValueHorsie, 900)
+    UCI_OPTION(SEEValueBishop, 1054)
+    UCI_OPTION(SEEValueRook, 1332);
+    UCI_OPTION(SEEValueQueen, 2300);
 
     UCI_OPTION(ValuePawn, 171)
     UCI_OPTION(ValueHorsie, 794)

--- a/src/types.h
+++ b/src/types.h
@@ -35,7 +35,7 @@
 namespace Horsie {
 
     constexpr auto InitialFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-    constexpr auto EngVersion = "1.0.4";
+    constexpr auto EngVersion = "1.0.5";
 
 constexpr u64 FileABB = 0x0101010101010101ULL;
 constexpr u64 FileBBB = FileABB << 1;

--- a/src/util.h
+++ b/src/util.h
@@ -86,11 +86,11 @@ namespace Horsie {
 
     constexpr i32 GetSEEValue(i32 pt) {
         switch (pt) {
-        case PAWN  : return SEEValue_Pawn;
-        case HORSIE: return SEEValue_Horsie;
-        case BISHOP: return SEEValue_Bishop;
-        case ROOK  : return SEEValue_Rook;
-        case QUEEN : return SEEValue_Queen;
+        case PAWN  : return SEEValuePawn;
+        case HORSIE: return SEEValueHorsie;
+        case BISHOP: return SEEValueBishop;
+        case ROOK  : return SEEValueRook;
+        case QUEEN : return SEEValueQueen;
         default:     return 0;
         }
     }


### PR DESCRIPTION
Based on [Integral's implementation](https://github.com/aronpetko/integral/blob/main/src/engine/search/search.cc#L907). 

```
Elo   | 8.49 +- 3.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 7616 W: 1776 L: 1590 D: 4250
Penta | [13, 811, 1974, 997, 13]
```
https://somelizard.pythonanywhere.com/test/2237/