### PR TITLE
Simply QSearch futility recapture logic

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -844,7 +844,8 @@ namespace Horsie {
             const bool givesCheck = ((pos.State->CheckSquares[ourPiece] & SquareBB(moveTo)) != 0);
 
             if (bestScore > ScoreTTLoss) {
-                if (!(givesCheck || m.IsPromotion())
+                if (!givesCheck 
+                    && !m.IsPromotion()
                     && futility > -ScoreWin) {
 
                     if (legalMoves > 3 && !ss->InCheck) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -820,7 +820,6 @@ namespace Horsie {
             futility = (std::min(ss->StaticEval, static_cast<i16>(bestScore)) + QSFutileMargin);
         }
 
-        const auto prevSquare = (ss - 1)->CurrentMove == Move::Null() ? SQUARE_NB : (ss - 1)->CurrentMove.To();
         i32 legalMoves = 0;
         i32 checkEvasions = 0;
 
@@ -846,7 +845,6 @@ namespace Horsie {
 
             if (bestScore > ScoreTTLoss) {
                 if (!(givesCheck || m.IsPromotion())
-                    && (prevSquare != moveTo)
                     && futility > -ScoreWin) {
 
                     if (legalMoves > 3 && !ss->InCheck) {

--- a/src/types.h
+++ b/src/types.h
@@ -23,7 +23,7 @@
 namespace Horsie {
 
     constexpr auto InitialFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-    constexpr auto EngVersion = "1.0.9";
+    constexpr auto EngVersion = "1.0.10";
 
     constexpr u64 FileABB = 0x0101010101010101ULL;
     constexpr u64 FileBBB = FileABB << 1;


### PR DESCRIPTION
```
Elo   | 0.43 +- 2.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 21116 W: 4762 L: 4736 D: 11618
Penta | [21, 2529, 5442, 2535, 31]
```
https://somelizard.pythonanywhere.com/test/2315/