### PR TITLE
Always replace older TT entries

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -84,7 +84,8 @@ namespace Horsie {
 
         if (nodeType == TTNodeType::Exact
             || k != Key
-            || depth + (isPV ? 2 : 0) > _depth - 4 + DepthOffset) {
+            || age != Age()
+            || depth + (2 * isPV) > Depth() - 4) {
             
             Key = k;
             SetScore(score);

--- a/src/types.h
+++ b/src/types.h
@@ -23,7 +23,7 @@
 namespace Horsie {
 
     constexpr auto InitialFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-    constexpr auto EngVersion = "1.0.10";
+    constexpr auto EngVersion = "1.0.11";
 
     constexpr u64 FileABB = 0x0101010101010101ULL;
     constexpr u64 FileBBB = FileABB << 1;


### PR DESCRIPTION
```
Elo   | 2.27 +- 2.58 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 1.29 (-2.25, 2.89) [0.00, 3.00]
Games | N: 15894 W: 3563 L: 3459 D: 8872
Penta | [2, 1750, 4340, 1852, 3]
```
https://somelizard.pythonanywhere.com/test/2342/