### PR TITLE
Quiet move ordering bonus

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -44,6 +44,7 @@ namespace Horsie {
         constexpr u64 Hash() const { return State->Hash; }
         constexpr u64 PawnHash() const { return State->PawnHash; }
         constexpr u64 NonPawnHash(i32 pc) const { return State->NonPawnHash[pc]; }
+        constexpr i32 CapturedPiece() const { return State->CapturedPiece; }
 
         constexpr bool CanCastle(u64 boardOcc, u64 ourOcc, CastlingStatus cr) const {
             return HasCastlingRight(cr) && !CastlingImpeded(boardOcc, cr) && HasCastlingRook(ourOcc, cr);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -328,7 +328,7 @@ namespace Horsie {
             && (ss - 1)->CurrentMove != Move::Null() 
             && pos.State->CapturedPiece == NONE) {
 
-            int bonus = std::clamp(-5 * ((ss - 1)->StaticEval + ss->StaticEval), -50, 100);
+            int bonus = 2 * std::clamp(-5 * ((ss - 1)->StaticEval + ss->StaticEval), -50, 100);
             history->MainHistory[Not(us)][(ss - 1)->CurrentMove.GetMoveMask()] << bonus;
         }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -326,9 +326,10 @@ namespace Horsie {
 
         if (!(ss - 1)->InCheck 
             && (ss - 1)->CurrentMove != Move::Null() 
-            && pos.State->CapturedPiece == NONE) {
+            && pos.CapturedPiece() == NONE) {
 
-            int bonus = 2 * std::clamp(-5 * ((ss - 1)->StaticEval + ss->StaticEval), -50, 100);
+            const i32 val = -QuietOrderMult * ((ss - 1)->StaticEval + ss->StaticEval);
+            const auto bonus = std::clamp(val, -QuietOrderMin, (i32)QuietOrderMax);
             history->MainHistory[Not(us)][(ss - 1)->CurrentMove.GetMoveMask()] << bonus;
         }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -324,6 +324,13 @@ namespace Horsie {
                        ((ss - 4)->StaticEval != ScoreNone ? ss->StaticEval > (ss - 4)->StaticEval : true);
         }
 
+        if (!(ss - 1)->InCheck 
+            && (ss - 1)->CurrentMove != Move::Null() 
+            && pos.State->CapturedPiece == NONE) {
+
+            int bonus = std::clamp(-5 * ((ss - 1)->StaticEval + ss->StaticEval), -50, 100);
+            history->MainHistory[Not(us)][(ss - 1)->CurrentMove.GetMoveMask()] << bonus;
+        }
 
         if (UseRFP
             && !ss->TTPV

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -21,6 +21,10 @@ namespace Horsie {
     const i32 CorrectionGrain = 256;
     const i32 CorrectionMax = CorrectionGrain * 64;
 
+    UCI_OPTION(QuietOrderMin, 100)
+    UCI_OPTION(QuietOrderMax, 200)
+    UCI_OPTION(QuietOrderMult, 10)
+
     UCI_OPTION(SEMinDepth, 5)
     UCI_OPTION(SENumerator, 11)
     UCI_OPTION(SEDoubleMargin, 24)

--- a/src/types.h
+++ b/src/types.h
@@ -23,7 +23,7 @@
 namespace Horsie {
 
     constexpr auto InitialFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-    constexpr auto EngVersion = "1.0.11";
+    constexpr auto EngVersion = "1.0.12";
 
     constexpr u64 FileABB = 0x0101010101010101ULL;
     constexpr u64 FileBBB = FileABB << 1;


### PR DESCRIPTION
```
Elo   | 6.81 +- 3.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 9590 W: 2242 L: 2054 D: 5294
Penta | [12, 1048, 2491, 1228, 16]
```
https://somelizard.pythonanywhere.com/test/2362/