### PR TITLE
Reasonable SEE values

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -916,11 +916,11 @@ namespace Horsie {
 
         const auto [moveFrom, moveTo] = move.Unpack();
 
-        i32 swap = GetSEEValue(bb.PieceTypes[moveTo]) - threshold;
+        i32 swap = GetSEEValue(bb.GetPieceAtIndex(moveTo)) - threshold;
         if (swap < 0)
             return false;
 
-        swap = GetSEEValue(bb.PieceTypes[moveFrom]) - swap;
+        swap = GetSEEValue(bb.GetPieceAtIndex(moveFrom)) - swap;
         if (swap <= 0)
             return true;
 
@@ -952,33 +952,33 @@ namespace Horsie {
 
             if ((temp = stmAttackers & bb.Pieces[PAWN]) != 0) {
                 occ ^= SquareBB(lsb(temp));
-                if ((swap = GetSEEValue(PAWN) - swap) < res)
+                if ((swap = SEEValuePawn - swap) < res)
                     break;
 
                 attackers |= GetBishopMoves(moveTo, occ) & (bb.Pieces[BISHOP] | bb.Pieces[QUEEN]);
             }
             else if ((temp = stmAttackers & bb.Pieces[HORSIE]) != 0) {
                 occ ^= SquareBB(lsb(temp));
-                if ((swap = GetSEEValue(HORSIE) - swap) < res)
+                if ((swap = SEEValueHorsie - swap) < res)
                     break;
             }
             else if ((temp = stmAttackers & bb.Pieces[BISHOP]) != 0) {
                 occ ^= SquareBB(lsb(temp));
-                if ((swap = GetSEEValue(BISHOP) - swap) < res)
+                if ((swap = SEEValueBishop - swap) < res)
                     break;
 
                 attackers |= GetBishopMoves(moveTo, occ) & (bb.Pieces[BISHOP] | bb.Pieces[QUEEN]);
             }
             else if ((temp = stmAttackers & bb.Pieces[ROOK]) != 0) {
                 occ ^= SquareBB(lsb(temp));
-                if ((swap = GetSEEValue(ROOK) - swap) < res)
+                if ((swap = SEEValueRook - swap) < res)
                     break;
 
                 attackers |= GetRookMoves(moveTo, occ) & (bb.Pieces[ROOK] | bb.Pieces[QUEEN]);
             }
             else if ((temp = stmAttackers & bb.Pieces[QUEEN]) != 0) {
                 occ ^= SquareBB(lsb(temp));
-                if ((swap = GetSEEValue(QUEEN) - swap) < res)
+                if ((swap = SEEValueQueen - swap) < res)
                     break;
 
                 attackers |= (GetBishopMoves(moveTo, occ) & (bb.Pieces[BISHOP] | bb.Pieces[QUEEN])) | (GetRookMoves(moveTo, occ) & (bb.Pieces[ROOK] | bb.Pieces[QUEEN]));

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -538,7 +538,8 @@ namespace Horsie {
                     continue;
                 }
 
-                if ((!isQuiet || skipQuiets) && !pos.SEE_GE(m, -ShallowSEEMargin * depth)) {
+                const auto seeMargin = -ShallowSEEMargin * depth;
+                if ((!isQuiet || skipQuiets) && !pos.SEE_GE(m, seeMargin)) {
                     continue;
                 }
             }
@@ -1100,9 +1101,9 @@ namespace Horsie {
         for (i32 i = 0; i < size; i++) {
             Move m = list[i].move;
 
-            list[i].score = GetSEEValue(m.IsEnPassant() ? PAWN : bb.GetPieceAtIndex(m.To()));
+            list[i].score = m.IsEnPassant() ? PAWN : bb.GetPieceAtIndex(m.To());
             if (m.IsPromotion()) {
-                list[i].score += GetSEEValue(QUEEN) + 1;
+                list[i].score += 10;
             }
         }
     }

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -56,7 +56,7 @@ namespace Horsie {
     UCI_OPTION(NMFutMarginB, 180)
     UCI_OPTION(NMFutMarginM, 81)
     UCI_OPTION(NMFutMarginDiv, 139)
-    UCI_OPTION(ShallowSEEMargin, 216)
+    UCI_OPTION(ShallowSEEMargin, 80)
     UCI_OPTION(ShallowMaxDepth, 9)
 
     UCI_OPTION(LMRQuietDiv, 12948)
@@ -81,10 +81,11 @@ namespace Horsie {
     UCI_OPTION(StatMalusMax, 1441)
 
     UCI_OPTION(SEEValuePawn, 105)
-    UCI_OPTION(SEEValueHorsie, 900)
-    UCI_OPTION(SEEValueBishop, 1054)
-    UCI_OPTION(SEEValueRook, 1332)
-    UCI_OPTION(SEEValueQueen, 2300)
+    UCI_OPTION(SEEValueHorsie, 300)
+    UCI_OPTION(SEEValueBishop, 315)
+    UCI_OPTION(SEEValueRook, 535)
+    UCI_OPTION(SEEValueQueen, 970)
+
     UCI_OPTION(ValuePawn, 171)
     UCI_OPTION(ValueHorsie, 794)
     UCI_OPTION(ValueBishop, 943)

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -80,11 +80,11 @@ namespace Horsie {
     UCI_OPTION(StatMalusSub, 102)
     UCI_OPTION(StatMalusMax, 1441)
 
-    UCI_OPTION(SEEValuePawn, 105)
-    UCI_OPTION(SEEValueHorsie, 300)
-    UCI_OPTION(SEEValueBishop, 315)
-    UCI_OPTION(SEEValueRook, 535)
-    UCI_OPTION(SEEValueQueen, 970)
+    CONST_OPTION(SEEValuePawn, 105)
+    CONST_OPTION(SEEValueHorsie, 300)
+    CONST_OPTION(SEEValueBishop, 315)
+    CONST_OPTION(SEEValueRook, 535)
+    CONST_OPTION(SEEValueQueen, 970)
 
     UCI_OPTION(ValuePawn, 171)
     UCI_OPTION(ValueHorsie, 794)

--- a/src/tunable.h
+++ b/src/tunable.h
@@ -110,3 +110,8 @@ inline TunableOption& AddUCIOption(const std::string& name, i32 v) {
 //  Spin option, i.e. UCI_Chess960
 #define UCI_OPTION_SPIN(Name, Default) \
     inline TunableOption& Name = AddUCIOption(#Name, Default, false, true, 1, true);
+
+//  Temporarily constant
+#define CONST_OPTION(Name, Default) \
+    constexpr i32 Name = Default;
+

--- a/src/types.h
+++ b/src/types.h
@@ -23,7 +23,7 @@
 namespace Horsie {
 
     constexpr auto InitialFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-    constexpr auto EngVersion = "1.0.13";
+    constexpr auto EngVersion = "1.0.14";
 
     constexpr u64 FileABB = 0x0101010101010101ULL;
     constexpr u64 FileBBB = FileABB << 1;


### PR DESCRIPTION
```
Elo   | -0.66 +- 1.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 59810 W: 13191 L: 13305 D: 33314
Penta | [77, 7128, 15627, 6978, 95]
```
http://somelizard.pythonanywhere.com/test/2405/