### PR TITLE
Linear LMR deepen equation

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -625,7 +625,7 @@ namespace Horsie {
                 score = -Negamax<NonPVNode>(pos, ss + 1, -alpha - 1, -alpha, reducedDepth, true);
 
                 if (score > alpha && R > 1) {
-                    newDepth += (score > (bestScore + 50 + 4 * newDepth));
+                    newDepth += (score > (bestScore + DeeperMargin + 4 * newDepth));
                     newDepth -= (score < (bestScore + newDepth));
 
                     if (newDepth - 1 > reducedDepth) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -624,8 +624,8 @@ namespace Horsie {
                 score = -Negamax<NonPVNode>(pos, ss + 1, -alpha - 1, -alpha, reducedDepth, true);
 
                 if (score > alpha && R > 1) {
-                    newDepth += (score > (bestScore + LMRExtMargin)) ? 1 : 0;
-                    newDepth -= (score < (bestScore + newDepth)) ? 1 : 0;
+                    newDepth += (score > (bestScore + 50 + 4 * newDepth));
+                    newDepth -= (score < (bestScore + newDepth));
 
                     if (newDepth - 1 > reducedDepth) {
                         score = -Negamax<NonPVNode>(pos, ss + 1, -alpha - 1, -alpha, newDepth - 1, !cutNode);

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -61,7 +61,8 @@ namespace Horsie {
 
     UCI_OPTION(LMRQuietDiv, 12948)
     UCI_OPTION(LMRCaptureDiv, 9424)
-    UCI_OPTION(LMRExtMargin, 132)
+
+    UCI_OPTION(DeeperMargin, 50)
 
     UCI_OPTION(QSFutileMargin, 187)
     UCI_OPTION(QSSeeMargin, 78)

--- a/src/types.h
+++ b/src/types.h
@@ -23,7 +23,7 @@
 namespace Horsie {
 
     constexpr auto InitialFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-    constexpr auto EngVersion = "1.0.14";
+    constexpr auto EngVersion = "1.0.15";
 
     constexpr u64 FileABB = 0x0101010101010101ULL;
     constexpr u64 FileBBB = FileABB << 1;


### PR DESCRIPTION
```
Elo   | 2.67 +- 3.93 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 0.70 (-2.25, 2.89) [0.00, 3.00]
Games | N: 7028 W: 1578 L: 1524 D: 3926
Penta | [1, 790, 1878, 844, 1]
```
http://somelizard.pythonanywhere.com/test/2424/