### PR TITLE
Use threats in quiet move ordering

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -122,4 +122,26 @@ namespace Horsie {
             return 0;
         };
     }
+
+
+    template u64 Bitboard::AttackMask<PAWN>(i32 idx, i32 pc, u64 occupied) const;
+    template u64 Bitboard::AttackMask<HORSIE>(i32 idx, i32 pc, u64 occupied) const;
+    template u64 Bitboard::AttackMask<BISHOP>(i32 idx, i32 pc, u64 occupied) const;
+    template u64 Bitboard::AttackMask<ROOK>(i32 idx, i32 pc, u64 occupied) const;
+    template u64 Bitboard::AttackMask<QUEEN>(i32 idx, i32 pc, u64 occupied) const;
+    template u64 Bitboard::AttackMask<KING>(i32 idx, i32 pc, u64 occupied) const;
+
+    template<i32 pt>
+    u64 Bitboard::AttackMask(i32 idx, i32 pc, u64 occupied) const {
+        switch (pt) {
+        case PAWN: return PawnAttackMasks[pc][idx];
+        case HORSIE: return PseudoAttacks[HORSIE][idx];
+        case BISHOP: return GetBishopMoves(idx, occupied);
+        case ROOK: return GetRookMoves(idx, occupied);
+        case QUEEN: return GetBishopMoves(idx, occupied) | GetRookMoves(idx, occupied);
+        case KING: return PseudoAttacks[KING][idx];
+        default:
+            return 0;
+        };
+    }
 }

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -33,6 +33,19 @@ namespace Horsie {
         u64 BlockingPieces(i32 pc, u64* pinners) const;
         u64 AttackersTo(i32 idx, u64 occupied) const;
         u64 AttackMask(i32 idx, i32 pc, i32 pt, u64 occupied) const;
+
+        template<i32 pt>
+        u64 AttackMask(i32 idx, i32 pc, u64 occupied) const;
+
+        template<i32 pt>
+        inline u64 ThreatsBy(i32 pc) const {
+            u64 mask{};
+            auto pieces = Pieces[pt] & Colors[pc];
+            while (pieces != 0)
+                mask |= AttackMask<pt>(poplsb(pieces), pc, Occupancy);
+
+            return mask;
+        }
     };
 
     struct BucketCache {

--- a/src/position.h
+++ b/src/position.h
@@ -46,6 +46,8 @@ namespace Horsie {
         constexpr u64 NonPawnHash(i32 pc) const { return State->NonPawnHash[pc]; }
         constexpr i32 CapturedPiece() const { return State->CapturedPiece; }
 
+        constexpr bool GivesCheck(i32 pt, i32 sq) const { return (State->CheckSquares[pt] & SquareBB(sq)); }
+
         constexpr bool CanCastle(u64 boardOcc, u64 ourOcc, CastlingStatus cr) const {
             return HasCastlingRight(cr) && !CastlingImpeded(boardOcc, cr) && HasCastlingRook(ourOcc, cr);
         }

--- a/src/position.h
+++ b/src/position.h
@@ -97,6 +97,10 @@ namespace Horsie {
         bool SEE_GE(Move m, i32 threshold = 1) const;
         bool HasCycle(i32 ply) const;
 
+        template<i32 pt>
+        constexpr u64 ThreatsBy(i32 pc) const {
+            return bb.ThreatsBy<pt>(pc);
+        }
 
         inline i32 PawnCorrectionIndex(i32 pc) const {
             return (pc * 16384) + static_cast<i32>(PawnHash() % 16384);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1149,6 +1149,10 @@ namespace Horsie {
         Bitboard& bb = pos.bb;
         const auto pc = pos.ToMove;
 
+        const auto pawnThreats = pos.ThreatsBy<PAWN>(Not(pc));
+        const auto minorThreats = pos.ThreatsBy<HORSIE>(Not(pc)) | pos.ThreatsBy<BISHOP>(Not(pc)) | pawnThreats;
+        const auto rookThreats = pos.ThreatsBy<ROOK>(Not(pc)) | minorThreats;
+
         for (i32 i = 0; i < size; i++) {
             Move m = list[i].move;
             const auto [moveFrom, moveTo] = m.Unpack();
@@ -1181,10 +1185,6 @@ namespace Horsie {
                 if ((pos.State->CheckSquares[pt] & SquareBB(moveTo)) != 0) {
                     list[i].score += CheckBonus;
                 }
-
-                const auto pawnThreats = pos.ThreatsBy<PAWN>(Not(pc));
-                const auto minorThreats = pos.ThreatsBy<HORSIE>(Not(pc)) | pos.ThreatsBy<BISHOP>(Not(pc)) | pawnThreats;
-                const auto rookThreats = pos.ThreatsBy<ROOK>(Not(pc)) | minorThreats;
 
                 i32 threat = 0;
                 const auto fromBB = SquareBB(moveFrom);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -514,7 +514,7 @@ namespace Horsie {
                 if (skipQuiets == false)
                     skipQuiets = legalMoves >= lmpMoves;
 
-                const bool givesCheck = ((pos.State->CheckSquares[ourPiece] & SquareBB(moveTo)) != 0);
+                const bool givesCheck = pos.GivesCheck(ourPiece, moveTo);
                 const bool isQuiet = !(givesCheck || isCapture);
 
                 if (isQuiet && skipQuiets && depth <= ShallowMaxDepth)
@@ -865,7 +865,7 @@ namespace Horsie {
             const auto ourPiece = bb.GetPieceAtIndex(moveFrom);
 
             const bool isCapture = pos.IsCapture(m);
-            const bool givesCheck = ((pos.State->CheckSquares[ourPiece] & SquareBB(moveTo)) != 0);
+            const bool givesCheck = pos.GivesCheck(ourPiece, moveTo);
 
             if (bestScore > ScoreTTLoss) {
                 if (!givesCheck 
@@ -1134,7 +1134,7 @@ namespace Horsie {
                 list[i].score +=     (*(ss - 4)->ContinuationHistory)[contIdx][moveTo];
                 list[i].score +=     (*(ss - 6)->ContinuationHistory)[contIdx][moveTo];
 
-                if ((pos.State->CheckSquares[pt] & SquareBB(moveTo)) != 0) {
+                if (pos.GivesCheck(pt, moveTo)) {
                     list[i].score += CheckBonus;
                 }
             }
@@ -1182,24 +1182,24 @@ namespace Horsie {
                     list[i].score += ((2 * LowPlyCount + 1) * history.PlyHistory[ss->Ply][m.GetMoveMask()]) / (2 * ss->Ply + 1);
                 }
 
-                if ((pos.State->CheckSquares[pt] & SquareBB(moveTo)) != 0) {
+                if (pos.GivesCheck(pt, moveTo)) {
                     list[i].score += CheckBonus;
                 }
 
                 i32 threat = 0;
                 const auto fromBB = SquareBB(moveFrom);
-                const auto toBB = SquareBB(moveTo);
+                const auto   toBB = SquareBB(moveTo);
                 if (pt == QUEEN) {
                     threat += ((fromBB & rookThreats) ? 12288 : 0);
-                    threat -= ((toBB & rookThreats) ? 11264 : 0);
+                    threat -= ((  toBB & rookThreats) ? 11264 : 0);
                 }
                 else if (pt == ROOK) {
                     threat += ((fromBB & minorThreats) ? 10240 : 0);
-                    threat -= ((toBB & minorThreats) ? 9216 : 0);
+                    threat -= ((  toBB & minorThreats) ? 9216 : 0);
                 }
                 else if (pt == BISHOP || pt == HORSIE) {
                     threat += ((fromBB & pawnThreats) ? 8192 : 0);
-                    threat -= ((toBB & pawnThreats) ? 7168 : 0);
+                    threat -= ((  toBB & pawnThreats) ? 7168 : 0);
                 }
 
                 list[i].score += threat;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1181,6 +1181,28 @@ namespace Horsie {
                 if ((pos.State->CheckSquares[pt] & SquareBB(moveTo)) != 0) {
                     list[i].score += CheckBonus;
                 }
+
+                const auto pawnThreats = pos.ThreatsBy<PAWN>(Not(pc));
+                const auto minorThreats = pos.ThreatsBy<HORSIE>(Not(pc)) | pos.ThreatsBy<BISHOP>(Not(pc)) | pawnThreats;
+                const auto rookThreats = pos.ThreatsBy<ROOK>(Not(pc)) | minorThreats;
+
+                i32 threat = 0;
+                const auto fromBB = SquareBB(moveFrom);
+                const auto toBB = SquareBB(moveTo);
+                if (pt == QUEEN) {
+                    threat += ((fromBB & rookThreats) ? 12288 : 0);
+                    threat -= ((toBB & rookThreats) ? 11264 : 0);
+                }
+                else if (pt == ROOK) {
+                    threat += ((fromBB & minorThreats) ? 10240 : 0);
+                    threat -= ((toBB & minorThreats) ? 9216 : 0);
+                }
+                else if (pt == BISHOP || pt == HORSIE) {
+                    threat += ((fromBB & pawnThreats) ? 8192 : 0);
+                    threat -= ((toBB & pawnThreats) ? 7168 : 0);
+                }
+
+                list[i].score += threat;
             }
 
             if (pt == HORSIE) {

--- a/src/types.h
+++ b/src/types.h
@@ -23,7 +23,7 @@
 namespace Horsie {
 
     constexpr auto InitialFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-    constexpr auto EngVersion = "1.0.15";
+    constexpr auto EngVersion = "1.0.16";
 
     constexpr u64 FileABB = 0x0101010101010101ULL;
     constexpr u64 FileBBB = FileABB << 1;


### PR DESCRIPTION
```
Elo   | 2.71 +- 1.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 29074 W: 6573 L: 6346 D: 16155
Penta | [26, 3297, 7672, 3508, 34]
```
https://somelizard.pythonanywhere.com/test/2459/