### PR TITLE
Do SE at low depths

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -588,7 +588,6 @@ namespace Horsie {
                 else if (depth < SEDepth
                          && !ss->InCheck
                          && eval < alpha - 25
-                       //&& tte->Bound() == BoundLower ?
                          && tte->Bound() & BoundLower) {
                     
                     extend = 1;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -548,36 +548,49 @@ namespace Horsie {
             if (UseSingularExtensions
                 && !isRoot
                 && !doSkip
-                && ss->Ply < RootDepth * 2
-                && depth >= (SEMinDepth + (isPV && tte->PV() ? 1 : 0))
                 && m == ttMove
-                && std::abs(ttScore) < ScoreWin
-                && ((tte->Bound() & BoundLower) != 0)
-                && tte->Depth() >= depth - 3) {
-                i32 singleBeta = ttScore - (SENumerator * depth / 10);
-                i32 singleDepth = (depth + SEDepthAdj) / 2;
+                && ss->Ply < RootDepth * 2
+                && std::abs(ttScore) < ScoreWin) {
 
-                ss->Skip = m;
-                score = Negamax<NonPVNode>(pos, ss, singleBeta - 1, singleBeta, singleDepth, cutNode);
-                ss->Skip = Move::Null();
+                const auto SEDepth = SEMinDepth + (isPV && tte->PV());
 
-                if (score < singleBeta) {
-                    bool doubleExt = !isPV && ss->DoubleExtensions <= 8 && (score < singleBeta - SEDoubleMargin);
-                    bool tripleExt = doubleExt && (score < singleBeta - SETripleMargin - (isCapture * SETripleCapSub));
+                if (depth >= SEDepth
+                    && ((tte->Bound() & BoundLower) != 0)
+                    && tte->Depth() >= depth - 3) {
 
-                    extend = 1 + doubleExt + tripleExt;
+                    i32 singleBeta = ttScore - (SENumerator * depth / 10);
+                    i32 singleDepth = (depth + SEDepthAdj) / 2;
+
+                    ss->Skip = m;
+                    score = Negamax<NonPVNode>(pos, ss, singleBeta - 1, singleBeta, singleDepth, cutNode);
+                    ss->Skip = Move::Null();
+
+                    if (score < singleBeta) {
+                        bool doubleExt = !isPV && ss->DoubleExtensions <= 8 && (score < singleBeta - SEDoubleMargin);
+                        bool tripleExt = doubleExt && (score < singleBeta - SETripleMargin - (isCapture * SETripleCapSub));
+
+                        extend = 1 + doubleExt + tripleExt;
+                    }
+                    else if (singleBeta >= beta) {
+                        return singleBeta;
+                    }
+                    else if (ttScore >= beta) {
+                        extend = -2 + isPV;
+                    }
+                    else if (cutNode) {
+                        extend = -2;
+                    }
+                    else if (ttScore <= alpha) {
+                        extend = -1;
+                    }
                 }
-                else if (singleBeta >= beta) {
-                    return singleBeta;
-                }
-                else if (ttScore >= beta) {
-                    extend = -2 + (isPV ? 1 : 0);
-                }
-                else if (cutNode) {
-                    extend = -2;
-                }
-                else if (ttScore <= alpha) {
-                    extend = -1;
+                else if (depth < SEDepth
+                         && !ss->InCheck
+                         && eval < alpha - 25
+                       //&& tte->Bound() == BoundLower ?
+                         && tte->Bound() & BoundLower) {
+                    
+                    extend = 1;
                 }
             }
 

--- a/src/types.h
+++ b/src/types.h
@@ -23,7 +23,7 @@
 namespace Horsie {
 
     constexpr auto InitialFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-    constexpr auto EngVersion = "1.0.18";
+    constexpr auto EngVersion = "1.0.19";
 
     constexpr u64 FileABB = 0x0101010101010101ULL;
     constexpr u64 FileBBB = FileABB << 1;


### PR DESCRIPTION
Implementation à la Stormphrax (based on a Koivisto idea)
```
Elo   | 3.41 +- 2.27 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 20864 W: 4747 L: 4542 D: 11575
Penta | [2, 2314, 5596, 2517, 3]
```
https://somelizard.pythonanywhere.com/test/2461/