### PR TITLE
Major refactor of board and accumulator states

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 EXE := horsie
 CXX := clang++
 
-SOURCES := src/bitboard.cpp src/cuckoo.cpp src/Horsie.cpp src/movegen.cpp src/position.cpp src/precomputed.cpp src/search.cpp src/threadpool.cpp src/tt.cpp src/uci.cpp src/wdl.cpp src/zobrist.cpp src/util/dbg_hit.cpp src/nnue/nn.cpp src/datagen/selfplay.cpp src/3rdparty/zstd/zstddeclib.c
+SOURCES := src/nnue/accumulator.cpp src/bitboard.cpp src/cuckoo.cpp src/Horsie.cpp src/movegen.cpp src/position.cpp src/precomputed.cpp src/search.cpp src/threadpool.cpp src/tt.cpp src/uci.cpp src/wdl.cpp src/zobrist.cpp src/util/dbg_hit.cpp src/nnue/nn.cpp src/datagen/selfplay.cpp src/3rdparty/zstd/zstddeclib.c
 
 
 ifeq ($(UNAME_S),Darwin)

--- a/src/datagen/selfplay.cpp
+++ b/src/datagen/selfplay.cpp
@@ -328,12 +328,9 @@ namespace Horsie::Datagen {
         td.Reset();
 
         ScoredMove rms[MoveListSize] = {};
-        i32 size = Generate<GenLegal>(pos, &rms[0], 0);
+        i32 size = Generate<GenLegal>(pos, rms, 0);
 
         td.RootMoves.clear();
-        td.RootMoves.shrink_to_fit();
-        td.RootMoves.reserve(size);
-
         for (i32 j = 0; j < size; j++) {
             td.RootMoves.push_back(RootMove(rms[j].move));
         }

--- a/src/nnue/accumulator.cpp
+++ b/src/nnue/accumulator.cpp
@@ -1,0 +1,258 @@
+
+#include "accumulator.h"
+
+#include "nn.h"
+#include "../bitboard.h"
+#include "../move.h"
+#include "../position.h"
+
+#include <cassert>
+
+namespace Horsie::NNUE {
+
+    void AccumulatorStack::MoveNext() {
+        if (++HeadIndex == AccStack.size()) {
+            AccStack.emplace_back();
+        }
+
+        CurrentAccumulator = &AccStack[HeadIndex];
+    }
+
+    void AccumulatorStack::UndoMove() {
+        assert(HeadIndex > 0);
+        HeadIndex--;
+
+        CurrentAccumulator = &AccStack[HeadIndex];
+    }
+
+    void AccumulatorStack::MakeMove(const Position& pos, Move m) {
+        const auto& bb = pos.bb;
+
+        MoveNext();
+
+        Accumulator* src = &AccStack[HeadIndex - 1];
+        Accumulator* dst = &AccStack[HeadIndex];
+
+        dst->NeedsRefresh[WHITE] = src->NeedsRefresh[WHITE];
+        dst->NeedsRefresh[BLACK] = src->NeedsRefresh[BLACK];
+
+        dst->Computed[WHITE] = dst->Computed[BLACK] = false;
+
+        const auto [moveFrom, moveTo] = m.Unpack();
+
+        const auto us = pos.ToMove;
+        const auto ourPiece = bb.GetPieceAtIndex(moveFrom);
+
+        const auto them = Not(us);
+        const auto theirPiece = bb.GetPieceAtIndex(moveTo);
+
+        PerspectiveUpdate& wUpdate = dst->Update[WHITE];
+        PerspectiveUpdate& bUpdate = dst->Update[BLACK];
+
+        wUpdate.Clear();
+        bUpdate.Clear();
+
+        if (ourPiece == KING && (KingBuckets[moveFrom ^ (56 * us)] != KingBuckets[moveTo ^ (56 * us)])) {
+            //  We will need to fully refresh our perspective, but we can still do theirs.
+            dst->NeedsRefresh[us] = true;
+
+            PerspectiveUpdate& theirUpdate = dst->Update[them];
+            i32 theirKing = pos.KingSquare(them);
+
+            i32 from = FeatureIndexSingle(us, ourPiece, moveFrom, theirKing, them);
+            i32 to = FeatureIndexSingle(us, ourPiece, moveTo, theirKing, them);
+
+            if (theirPiece != NONE && !m.IsCastle()) {
+                i32 cap = FeatureIndexSingle(them, theirPiece, moveTo, theirKing, them);
+
+                theirUpdate.PushSubSubAdd(from, cap, to);
+            }
+            else if (m.IsCastle()) {
+                i32 rookFromSq = moveTo;
+                i32 rookToSq = m.CastlingRookSquare();
+
+                to = FeatureIndexSingle(us, ourPiece, m.CastlingKingSquare(), theirKing, them);
+
+                i32 rookFrom = FeatureIndexSingle(us, ROOK, rookFromSq, theirKing, them);
+                i32 rookTo = FeatureIndexSingle(us, ROOK, rookToSq, theirKing, them);
+
+                theirUpdate.PushSubSubAddAdd(from, rookFrom, to, rookTo);
+            }
+            else {
+                theirUpdate.PushSubAdd(from, to);
+            }
+        }
+        else {
+            i32 wKing = pos.KingSquare(WHITE);
+            i32 bKing = pos.KingSquare(BLACK);
+
+            const auto [wFrom, bFrom] = FeatureIndex(us, ourPiece, moveFrom, wKing, bKing);
+            const auto [wTo, bTo] = FeatureIndex(us, m.IsPromotion() ? m.PromotionTo() : ourPiece, moveTo, wKing, bKing);
+
+            wUpdate.PushSubAdd(wFrom, wTo);
+            bUpdate.PushSubAdd(bFrom, bTo);
+
+            if (theirPiece != NONE) {
+                const auto [wCap, bCap] = FeatureIndex(them, theirPiece, moveTo, wKing, bKing);
+
+                wUpdate.PushSub(wCap);
+                bUpdate.PushSub(bCap);
+            }
+            else if (m.IsEnPassant()) {
+                i32 idxPawn = moveTo - ShiftUpDir(us);
+
+                const auto [wCap, bCap] = FeatureIndex(them, PAWN, idxPawn, wKing, bKing);
+
+                wUpdate.PushSub(wCap);
+                bUpdate.PushSub(bCap);
+            }
+        }
+    }
+
+
+    void AccumulatorStack::EnsureUpdated(Position& pos) {
+
+        for (i32 perspective = 0; perspective < 2; perspective++) {
+            //  If the current state is correct for our perspective, no work is needed
+            if (CurrentAccumulator->Computed[perspective])
+                continue;
+
+            //  If the current state needs a refresh, don't bother with previous states
+            if (CurrentAccumulator->NeedsRefresh[perspective]) {
+                RefreshFromCache(pos, perspective);
+                continue;
+            }
+
+            //  Find the most recent computed or refresh-needed accumulator
+            Accumulator* curr = &AccStack[HeadIndex - 1];
+            while (!curr->Computed[perspective] && !curr->NeedsRefresh[perspective])
+                curr--;
+
+            if (curr->NeedsRefresh[perspective]) {
+                //  The most recent accumulator would need to be refreshed,
+                //  so don't bother and refresh the current one instead
+                RefreshFromCache(pos, perspective);
+            }
+            else {
+                //  Update incrementally till the current accumulator is correct
+                while (curr != CurrentAccumulator) {
+                    Accumulator* prev = curr;
+                    curr++;
+                    ProcessUpdate(prev, curr, perspective);
+                }
+            }
+        }
+    }
+
+    void AccumulatorStack::ProcessUpdate(Accumulator* prev, Accumulator* curr, i32 perspective) {
+        auto FeatureWeights = reinterpret_cast<const i16*>(&net.FTWeights[0]);
+        const auto& updates = curr->Update[perspective];
+
+        assert(updates.AddCnt != 0 || updates.SubCnt != 0);
+
+        auto src = reinterpret_cast<i16*>(&prev->Sides[perspective]);
+        auto dst = reinterpret_cast<i16*>(&curr->Sides[perspective]);
+        if (updates.AddCnt == 1 && updates.SubCnt == 1) {
+            SubAdd(src, dst,
+                   &FeatureWeights[updates.Subs[0]],
+                   &FeatureWeights[updates.Adds[0]]);
+        }
+        else if (updates.AddCnt == 1 && updates.SubCnt == 2) {
+            SubSubAdd(src, dst,
+                      &FeatureWeights[updates.Subs[0]],
+                      &FeatureWeights[updates.Subs[1]],
+                      &FeatureWeights[updates.Adds[0]]);
+        }
+        else if (updates.AddCnt == 2 && updates.SubCnt == 2) {
+            SubSubAddAdd(src, dst,
+                         &FeatureWeights[updates.Subs[0]],
+                         &FeatureWeights[updates.Subs[1]],
+                         &FeatureWeights[updates.Adds[0]],
+                         &FeatureWeights[updates.Adds[1]]);
+        }
+        curr->Computed[perspective] = true;
+    }
+
+
+    void AccumulatorStack::RefreshIntoCache(Position& pos) {
+        RefreshIntoCache(pos, WHITE);
+        RefreshIntoCache(pos, BLACK);
+    }
+
+    void AccumulatorStack::RefreshIntoCache(Position& pos, i32 perspective) {
+        auto accumulator = CurrentAccumulator;
+        Bitboard& bb = pos.bb;
+
+        accumulator->Sides[perspective] = net.FTBiases;
+        accumulator->NeedsRefresh[perspective] = false;
+        accumulator->Computed[perspective] = true;
+
+        i32 ourKing = pos.KingSquare(perspective);
+        u64 occ = bb.Occupancy;
+        while (occ != 0) {
+            i32 pieceIdx = poplsb(occ);
+
+            i32 pt = bb.GetPieceAtIndex(pieceIdx);
+            i32 pc = bb.GetColorAtIndex(pieceIdx);
+
+            i32 idx = FeatureIndexSingle(pc, pt, pieceIdx, ourKing, perspective);
+
+            const auto accum = reinterpret_cast<i16*>(&accumulator->Sides[perspective]);
+            const auto weights = &net.FTWeights[idx];
+            Add(accum, accum, weights);
+        }
+
+        auto& cache = pos.CachedBuckets[BucketForPerspective(ourKing, perspective)];
+        auto& entryBB = cache.Boards[perspective];
+        auto& entryAcc = cache.accumulator;
+
+        accumulator->CopyTo(entryAcc, perspective);
+        bb.CopyTo(entryBB);
+    }
+
+    void AccumulatorStack::RefreshFromCache(Position& pos, i32 perspective) {
+        auto accumulator = CurrentAccumulator;
+        Bitboard& bb = pos.bb;
+
+        i32 ourKing = pos.KingSquare(perspective);
+
+        auto& rtEntry = pos.CachedBuckets[BucketForPerspective(ourKing, perspective)];
+        auto& entryBB = rtEntry.Boards[perspective];
+        auto& entryAcc = rtEntry.accumulator;
+
+        auto ourAccumulation = reinterpret_cast<i16*>(&entryAcc.Sides[perspective]);
+        accumulator->NeedsRefresh[perspective] = false;
+
+        for (i32 pc = 0; pc < COLOR_NB; pc++) {
+            for (i32 pt = 0; pt < PIECE_NB; pt++) {
+                u64 prev = entryBB.Pieces[pt] & entryBB.Colors[pc];
+                u64 curr =      bb.Pieces[pt] &      bb.Colors[pc];
+
+                u64 added   = curr & ~prev;
+                u64 removed = prev & ~curr;
+
+                while (added != 0) {
+                    i32 sq = poplsb(added);
+                    i32 idx = FeatureIndexSingle(pc, pt, sq, ourKing, perspective);
+
+                    const auto weights = &net.FTWeights[idx];
+                    Add(ourAccumulation, ourAccumulation, weights);
+                }
+
+                while (removed != 0) {
+                    i32 sq = poplsb(removed);
+                    i32 idx = FeatureIndexSingle(pc, pt, sq, ourKing, perspective);
+
+                    const auto weights = &net.FTWeights[idx];
+                    Sub(ourAccumulation, ourAccumulation, weights);
+                }
+            }
+        }
+
+        entryAcc.CopyTo(accumulator, perspective);
+        bb.CopyTo(entryBB);
+
+        accumulator->Computed[perspective] = true;
+    }
+
+}

--- a/src/nnue/nn.cpp
+++ b/src/nnue/nn.cpp
@@ -137,86 +137,6 @@ namespace Horsie::NNUE {
         }
     }
 
-    void RefreshAccumulator(Position& pos) {
-        RefreshAccumulatorPerspectiveFull(pos, WHITE);
-        RefreshAccumulatorPerspectiveFull(pos, BLACK);
-    }
-
-    void RefreshAccumulatorPerspectiveFull(Position& pos, i32 perspective) {
-        auto accumulator = pos.CurrAccumulator();
-        Bitboard& bb = pos.bb;
-
-        accumulator->Sides[perspective] = g_network->FTBiases;
-        accumulator->NeedsRefresh[perspective] = false;
-        accumulator->Computed[perspective] = true;
-
-        i32 ourKing = pos.KingSquare(perspective);
-        u64 occ = bb.Occupancy;
-        while (occ != 0) {
-            i32 pieceIdx = poplsb(occ);
-
-            i32 pt = bb.GetPieceAtIndex(pieceIdx);
-            i32 pc = bb.GetColorAtIndex(pieceIdx);
-
-            i32 idx = FeatureIndexSingle(pc, pt, pieceIdx, ourKing, perspective);
-
-            const auto accum = reinterpret_cast<i16*>(&accumulator->Sides[perspective]);
-            const auto weights = &net.FTWeights[idx];
-            Add(accum, accum, weights);
-        }
-
-        auto& cache = pos.CachedBuckets[BucketForPerspective(ourKing, perspective)];
-        auto& entryBB = cache.Boards[perspective];
-        auto& entryAcc = cache.accumulator;
-
-        accumulator->CopyTo(entryAcc, perspective);
-        bb.CopyTo(entryBB);
-    }
-
-    void RefreshAccumulatorPerspective(Position& pos, i32 perspective) {
-        auto accumulator = pos.CurrAccumulator();
-        Bitboard& bb = pos.bb;
-
-        i32 ourKing = pos.KingSquare(perspective);
-
-        auto& rtEntry = pos.CachedBuckets[BucketForPerspective(ourKing, perspective)];
-        auto& entryBB = rtEntry.Boards[perspective];
-        auto& entryAcc = rtEntry.accumulator;
-
-        auto ourAccumulation = reinterpret_cast<i16*>(&entryAcc.Sides[perspective]);
-        accumulator->NeedsRefresh[perspective] = false;
-
-        for (i32 pc = 0; pc < COLOR_NB; pc++) {
-            for (i32 pt = 0; pt < PIECE_NB; pt++) {
-                u64 prev = entryBB.Pieces[pt] & entryBB.Colors[pc];
-                u64 curr = bb.Pieces[pt] & bb.Colors[pc];
-
-                u64 added = curr & ~prev;
-                u64 removed = prev & ~curr;
-
-                while (added != 0) {
-                    i32 sq = poplsb(added);
-                    i32 idx = FeatureIndexSingle(pc, pt, sq, ourKing, perspective);
-
-                    const auto weights = &net.FTWeights[idx];
-                    Add(ourAccumulation, ourAccumulation, weights);
-                }
-
-                while (removed != 0) {
-                    i32 sq = poplsb(removed);
-                    i32 idx = FeatureIndexSingle(pc, pt, sq, ourKing, perspective);
-
-                    const auto weights = &net.FTWeights[idx];
-                    Sub(ourAccumulation, ourAccumulation, weights);
-                }
-            }
-        }
-
-        entryAcc.CopyTo(accumulator, perspective);
-        bb.CopyTo(entryBB);
-
-        accumulator->Computed[perspective] = true;
-    }
 
     i32 GetEvaluation(Position& pos) {
         const auto occ = popcount(pos.bb.Occupancy);
@@ -226,11 +146,11 @@ namespace Horsie::NNUE {
     }
 
     i32 GetEvaluation(Position& pos, i32 outputBucket) {
-        auto accumulator = pos.CurrAccumulator();
-        ProcessUpdates(pos);
+        const auto accumulator = pos.CurrAccumulator();
+        pos.Accumulators.EnsureUpdated(pos);
 
-        auto us = Span<i16>(accumulator->Sides[pos.ToMove]);
-        auto them = Span<i16>(accumulator->Sides[Not(pos.ToMove)]);
+        const auto us = Span<i16>(accumulator->Sides[pos.ToMove]);
+        const auto them = Span<i16>(accumulator->Sides[Not(pos.ToMove)]);
 
         i8 ft_outputs[L1_SIZE];
         float L1Outputs[L2_SIZE];
@@ -365,166 +285,6 @@ namespace Horsie::NNUE {
         return static_cast<i32>(L3Output * OutputScale);
     }
 
-    void MakeMoveNN(Position& pos, Move m) {
-        Bitboard& bb = pos.bb;
-
-        Accumulator* src = pos.CurrAccumulator();
-        Accumulator* dst = pos.NextAccumulator();
-
-        dst->NeedsRefresh[WHITE] = src->NeedsRefresh[WHITE];
-        dst->NeedsRefresh[BLACK] = src->NeedsRefresh[BLACK];
-
-        dst->Computed[WHITE] = dst->Computed[BLACK] = false;
-
-        const auto [moveFrom, moveTo] = m.Unpack();
-
-        const auto us = pos.ToMove;
-        const auto ourPiece = bb.GetPieceAtIndex(moveFrom);
-
-        const auto them = Not(us);
-        const auto theirPiece = bb.GetPieceAtIndex(moveTo);
-
-        PerspectiveUpdate& wUpdate = dst->Update[WHITE];
-        PerspectiveUpdate& bUpdate = dst->Update[BLACK];
-
-        wUpdate.Clear();
-        bUpdate.Clear();
-
-        if (ourPiece == KING && (KingBuckets[moveFrom ^ (56 * us)] != KingBuckets[moveTo ^ (56 * us)])) {
-            //  We will need to fully refresh our perspective, but we can still do theirs.
-            dst->NeedsRefresh[us] = true;
-
-            PerspectiveUpdate& theirUpdate = dst->Update[them];
-            i32 theirKing = pos.KingSquare(them);
-
-            i32 from = FeatureIndexSingle(us, ourPiece, moveFrom, theirKing, them);
-            i32 to = FeatureIndexSingle(us, ourPiece, moveTo, theirKing, them);
-
-            if (theirPiece != NONE && !m.IsCastle()) {
-                i32 cap = FeatureIndexSingle(them, theirPiece, moveTo, theirKing, them);
-
-                theirUpdate.PushSubSubAdd(from, cap, to);
-            }
-            else if (m.IsCastle()) {
-                i32 rookFromSq = moveTo;
-                i32 rookToSq = m.CastlingRookSquare();
-
-                to = FeatureIndexSingle(us, ourPiece, m.CastlingKingSquare(), theirKing, them);
-
-                i32 rookFrom = FeatureIndexSingle(us, ROOK, rookFromSq, theirKing, them);
-                i32 rookTo = FeatureIndexSingle(us, ROOK, rookToSq, theirKing, them);
-
-                theirUpdate.PushSubSubAddAdd(from, rookFrom, to, rookTo);
-            }
-            else {
-                theirUpdate.PushSubAdd(from, to);
-            }
-        }
-        else {
-            i32 wKing = pos.KingSquare(WHITE);
-            i32 bKing = pos.KingSquare(BLACK);
-
-            const auto [wFrom, bFrom] = FeatureIndex(us, ourPiece, moveFrom, wKing, bKing);
-            const auto [wTo, bTo] = FeatureIndex(us, m.IsPromotion() ? m.PromotionTo() : ourPiece, moveTo, wKing, bKing);
-
-            wUpdate.PushSubAdd(wFrom, wTo);
-            bUpdate.PushSubAdd(bFrom, bTo);
-
-            if (theirPiece != NONE) {
-                const auto [wCap, bCap] = FeatureIndex(them, theirPiece, moveTo, wKing, bKing);
-
-                wUpdate.PushSub(wCap);
-                bUpdate.PushSub(bCap);
-            }
-            else if (m.IsEnPassant()) {
-                i32 idxPawn = moveTo - ShiftUpDir(us);
-
-                const auto [wCap, bCap] = FeatureIndex(them, PAWN, idxPawn, wKing, bKing);
-
-                wUpdate.PushSub(wCap);
-                bUpdate.PushSub(bCap);
-            }
-        }
-    }
-
-    void MakeNullMove(Position& pos) {
-        Accumulator* currAcc = pos.CurrAccumulator();
-        Accumulator* nextAcc = pos.NextAccumulator();
-
-        currAcc->CopyTo(nextAcc);
-
-        nextAcc->Computed[WHITE] = currAcc->Computed[WHITE];
-        nextAcc->Computed[BLACK] = currAcc->Computed[BLACK];
-        nextAcc->Update[WHITE].Clear();
-        nextAcc->Update[BLACK].Clear();
-    }
-
-    void ProcessUpdates(Position& pos) {
-        StateInfo* st = pos.State;
-        for (i32 perspective = 0; perspective < 2; perspective++) {
-            //  If the current state is correct for our perspective, no work is needed
-            if (st->accumulator->Computed[perspective])
-                continue;
-
-            //  If the current state needs a refresh, don't bother with previous states
-            if (st->accumulator->NeedsRefresh[perspective]) {
-                RefreshAccumulatorPerspective(pos, perspective);
-                continue;
-            }
-
-            //  Find the most recent computed or refresh-needed accumulator
-            StateInfo* curr = st - 1;
-            while (!curr->accumulator->Computed[perspective] && !curr->accumulator->NeedsRefresh[perspective])
-                curr--;
-
-            if (curr->accumulator->NeedsRefresh[perspective]) {
-                //  The most recent accumulator would need to be refreshed,
-                //  so don't bother and refresh the current one instead
-                RefreshAccumulatorPerspective(pos, perspective);
-            }
-            else {
-                //  Update incrementally till the current accumulator is correct
-                while (curr != st) {
-                    StateInfo* prev = curr;
-                    curr++;
-                    UpdateSingle(prev->accumulator, curr->accumulator, perspective);
-                }
-            }
-        }
-    }
-
-    void UpdateSingle(Accumulator* prev, Accumulator* curr, i32 perspective) {
-        auto FeatureWeights = reinterpret_cast<const i16*>(&g_network->FTWeights[0]);
-        const auto& updates = curr->Update[perspective];
-
-        if (updates.AddCnt == 0 && updates.SubCnt == 0) {
-            //  For null moves, we still need to carry forward the correct accumulator state
-            prev->CopyTo(curr, perspective);
-            return;
-        }
-
-        auto src = reinterpret_cast<i16*>(&prev->Sides[perspective]);
-        auto dst = reinterpret_cast<i16*>(&curr->Sides[perspective]);
-        if (updates.AddCnt == 1 && updates.SubCnt == 1) {
-            SubAdd(src, dst,
-                   &FeatureWeights[updates.Subs[0]],
-                   &FeatureWeights[updates.Adds[0]]);
-        }
-        else if (updates.AddCnt == 1 && updates.SubCnt == 2) {
-            SubSubAdd(src, dst,
-                      &FeatureWeights[updates.Subs[0]],
-                      &FeatureWeights[updates.Subs[1]],
-                      &FeatureWeights[updates.Adds[0]]);
-        }
-        else if (updates.AddCnt == 2 && updates.SubCnt == 2) {
-            SubSubAddAdd(src, dst,
-                         &FeatureWeights[updates.Subs[0]],
-                         &FeatureWeights[updates.Subs[1]],
-                         &FeatureWeights[updates.Adds[0]],
-                         &FeatureWeights[updates.Adds[1]]);
-        }
-        curr->Computed[perspective] = true;
-    }
 
     std::pair<i32, i32> FeatureIndex(i32 pc, i32 pt, i32 sq, i32 wk, i32 bk) {
         const i32 ColorStride = 64 * 6;
@@ -566,6 +326,7 @@ namespace Horsie::NNUE {
 
         return ((768 * KingBuckets[kingSq]) + ((pc ^ perspective) * ColorStride) + (pt * PieceStride) + (sq)) * L1_SIZE;
     }
+
 
     void ResetCaches(Position& pos) {
         for (auto& bucket : pos.CachedBuckets) {
@@ -702,7 +463,7 @@ namespace Horsie::NNUE {
         delete[] temp;
     }
 
-    static void SubSubAddAdd(const i16* _src, i16* _dst, const i16* _sub1, const i16* _sub2, const i16* _add1, const i16* _add2) {
+    void SubSubAddAdd(const i16* _src, i16* _dst, const i16* _sub1, const i16* _sub2, const i16* _add1, const i16* _add2) {
         const vec_i16* src = reinterpret_cast<const vec_i16*>(_src);
         vec_i16* dst = reinterpret_cast<vec_i16*>(_dst);
         const vec_i16* sub1 = reinterpret_cast<const vec_i16*>(_sub1);
@@ -714,7 +475,7 @@ namespace Horsie::NNUE {
         }
     }
 
-    static void SubSubAdd(const i16* _src, i16* _dst, const i16* _sub1, const i16* _sub2, const i16* _add1) {
+    void SubSubAdd(const i16* _src, i16* _dst, const i16* _sub1, const i16* _sub2, const i16* _add1) {
         const vec_i16* src = reinterpret_cast<const vec_i16*>(_src);
         vec_i16* dst = reinterpret_cast<vec_i16*>(_dst);
         const vec_i16* sub1 = reinterpret_cast<const vec_i16*>(_sub1);
@@ -725,7 +486,7 @@ namespace Horsie::NNUE {
         }
     }
 
-    static void SubAdd(const i16* _src, i16* _dst, const i16* _sub1, const i16* _add1) {
+    void SubAdd(const i16* _src, i16* _dst, const i16* _sub1, const i16* _add1) {
         const vec_i16* src = reinterpret_cast<const vec_i16*>(_src);
         vec_i16* dst = reinterpret_cast<vec_i16*>(_dst);
         const vec_i16* sub1 = reinterpret_cast<const vec_i16*>(_sub1);
@@ -735,7 +496,7 @@ namespace Horsie::NNUE {
         }
     }
 
-    static void Add(const i16* _src, i16* _dst, const i16* _add1) {
+    void Add(const i16* _src, i16* _dst, const i16* _add1) {
         const vec_i16* src = reinterpret_cast<const vec_i16*>(_src);
         vec_i16* dst = reinterpret_cast<vec_i16*>(_dst);
         const vec_i16* add1 = reinterpret_cast<const vec_i16*>(_add1);
@@ -743,7 +504,7 @@ namespace Horsie::NNUE {
             dst[i] = vec_add_epi16(src[i], add1[i]);
     }
 
-    static void Sub(const i16* _src, i16* _dst, const i16* _sub1) {
+    void Sub(const i16* _src, i16* _dst, const i16* _sub1) {
         const vec_i16* src = reinterpret_cast<const vec_i16*>(_src);
         vec_i16* dst = reinterpret_cast<vec_i16*>(_dst);
         const vec_i16* sub1 = reinterpret_cast<const vec_i16*>(_sub1);

--- a/src/nnue/nn.h
+++ b/src/nnue/nn.h
@@ -66,25 +66,8 @@ namespace Horsie::NNUE {
     static void PermuteFT(Span<i16> ftWeights, Span<i16> ftBiases);
     static void PermuteL1(i8 l1Weights[L1_SIZE][OUTPUT_BUCKETS][L2_SIZE]);
 
-
-    void RefreshAccumulator(Position& pos);
-    void RefreshAccumulatorPerspectiveFull(Position& pos, i32 perspective);
-    void RefreshAccumulatorPerspective(Position& pos, i32 perspective);
-
-
-    void MakeMoveNN(Position& pos, Move m);
-    void MakeNullMove(Position& pos);
-    void UpdateSingle(Accumulator* prev, Accumulator* curr, i32 perspective);
-    void ProcessUpdates(Position& pos);
-
-
     i32 GetEvaluation(Position& pos, i32 outputBucket);
     i32 GetEvaluation(Position& pos);
-    static void ActivateFTSparse(Span<i16> us, Span<i16> them, Span<i8> weights, Span<float> biases, Span<float> output);
-    static void ActivateL1Sparse(Span<i8> inputs, Span<i8> weights, Span<float> biases, Span<float> output, Span<u16> nnzIndices, const i32 nnzCount);
-    static void ActivateL2(Span<float> inputs, Span<float> weights, Span<float> biases, Span<float> output);
-    static void ActivateL3(Span<float> inputs, Span<float> weights, const float bias, float& output);
-
 
     std::pair<i32, i32> FeatureIndex(i32 pc, i32 pt, i32 sq, i32 wk, i32 bk);
     i32 FeatureIndexSingle(i32 pc, i32 pt, i32 sq, i32 kingSq, i32 perspective);
@@ -115,11 +98,11 @@ namespace Horsie::NNUE {
 
     void ResetCaches(Position& pos);
 
-    static void Sub(const i16* src, i16* dst, const i16* sub1);
-    static void Add(const i16* src, i16* dst, const i16* add1);
-    static void SubAdd(const i16* src, i16* dst, const i16* sub1, const i16* add1);
-    static void SubSubAdd(const i16* src, i16* dst, const i16* sub1, const i16* sub2, const i16* add1);
-    static void SubSubAddAdd(const i16* src, i16* dst, const i16* sub1, const i16* sub2, const i16* add1, const i16* add2);
+    void Sub(const i16* src, i16* dst, const i16* sub1);
+    void Add(const i16* src, i16* dst, const i16* add1);
+    void SubAdd(const i16* src, i16* dst, const i16* sub1, const i16* add1);
+    void SubSubAdd(const i16* src, i16* dst, const i16* sub1, const i16* sub2, const i16* add1);
+    void SubSubAddAdd(const i16* src, i16* dst, const i16* sub1, const i16* sub2, const i16* add1, const i16* add2);
 
 
     constexpr i32 BestPermuteIndices[] = {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -524,8 +524,8 @@ namespace Horsie {
         return ((State->BlockingPieces[ourColor] & SquareBB(moveFrom)) == 0) || ((RayBB[moveFrom][moveTo] & SquareBB(ourKing)) != 0);
     }
 
-    bool Position::IsDraw() const {
-        return IsFiftyMoveDraw() || IsInsufficientMaterial() || IsThreefoldRepetition();
+    bool Position::IsDraw(i16 ply) const {
+        return IsFiftyMoveDraw() || IsInsufficientMaterial() || IsThreefoldRepetition(ply);
     }
 
     bool Position::IsInsufficientMaterial() const {
@@ -541,34 +541,23 @@ namespace Horsie {
         return (horsies == 0 && bishops < 2) || (bishops == 0 && horsies <= 2);
     }
 
-    bool Position::IsThreefoldRepetition() const {
-        //  At least 8 moves must be made before a draw can occur.
-        if (GamePly < 8) {
-            return false;
-        }
+    bool Position::IsThreefoldRepetition(i16 ply) const {
 
-        u64 currHash = State->Hash;
+        const auto currHash = State->Hash;
+        const auto dist = std::min(State->HalfmoveClock, GamePly);
 
-        //  Beginning with the current state's Hash, step backwards in increments of 2 until reaching the first move that we made.
-        //  If we encounter the current hash 2 additional times, then this is a draw.
+        bool rep = false;
+        const auto st = StartingState();
+        for (i32 i = 4; i <= dist; i += 2) {
 
-        i32 count = 0;
-        StateInfo* temp = State;
-        for (i32 i = 0; i < GamePly - 1; i += 2) {
-            if (temp->Hash == currHash) {
-                count++;
-
-                if (count == 3) {
+            if (st[GamePly - i].Hash == currHash) {
+                if (ply >= i || rep)
                     return true;
-                }
-            }
 
-            if ((temp - 1) == _SentinelStart || (temp - 2) == _SentinelStart) {
-                break;
+                rep = true;
             }
-
-            temp -= 2;
         }
+
         return false;
     }
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -530,7 +530,7 @@ namespace Horsie {
     }
 
     bool Position::IsDraw(i16 ply) const {
-        return IsFiftyMoveDraw() || IsInsufficientMaterial();// || IsThreefoldRepetition(ply);
+        return IsFiftyMoveDraw() || IsInsufficientMaterial() || IsThreefoldRepetition(ply);
     }
 
     bool Position::IsInsufficientMaterial() const {
@@ -548,14 +548,13 @@ namespace Horsie {
 
     bool Position::IsThreefoldRepetition(i16 ply) const {
 
-        const auto currHash = State->Hash;
-        const auto dist = std::min(State->HalfmoveClock, GamePly);
+        const auto histSize = static_cast<i32>(Hashes.size());
+        const auto dist = std::min(State->HalfmoveClock, histSize);
 
         bool rep = false;
-        const auto st = StartingState();
         for (i32 i = 4; i <= dist; i += 2) {
 
-            if (st[GamePly - i].Hash == currHash) {
+            if (Hashes[histSize - i] == State->Hash) {
                 if (ply >= i || rep)
                     return true;
 

--- a/src/position.h
+++ b/src/position.h
@@ -6,18 +6,18 @@
 #include "move.h"
 #include "nnue/accumulator.h"
 #include "types.h"
+#include "util/list.h"
 
 namespace Horsie {
 
     class Position {
     public:
         Position(const std::string& fen = InitialFEN);
-        ~Position();
         void LoadFromFEN(const std::string& fen);
 
         NNUE::AccumulatorStack Accumulators;
         NNUE::BucketCache CachedBuckets;
-        StateInfo* State;
+        StateInfo State;
 
         Bitboard bb{};
         Color ToMove{};
@@ -28,24 +28,22 @@ namespace Horsie {
 
         bool IsChess960{};
 
-        constexpr bool InCheck()       const { return State->Checkers != 0; }
-        constexpr bool InDoubleCheck() const { return MoreThanOne(State->Checkers); }
-        constexpr StateInfo* StartingState() const { return StateBlock; }
-        constexpr StateInfo* PreviousState() const { return State - 1; }
-        constexpr StateInfo* NextState() const { return State + 1; }
+        constexpr bool InCheck()       const { return State.Checkers != 0; }
+        constexpr bool InDoubleCheck() const { return MoreThanOne(State.Checkers); }
+        constexpr StateInfo& StartingState() { return States[0]; }
 
-        constexpr u64 CheckSquares(i32 pt) const { return State->CheckSquares[pt]; }
-        constexpr u64 BlockingPieces(i32 pc) const { return State->BlockingPieces[pc]; }
-        constexpr u64 Pinners(i32 pc) const { return State->Pinners[pc]; }
-        constexpr i32 KingSquare(i32 pc) const { return State->KingSquares[pc]; }
-        constexpr u64 Checkers() const { return State->Checkers; }
-        constexpr u64 Hash() const { return State->Hash; }
-        constexpr u64 PawnHash() const { return State->PawnHash; }
-        constexpr u64 NonPawnHash(i32 pc) const { return State->NonPawnHash[pc]; }
-        constexpr i32 HalfmoveClock() const { return State->HalfmoveClock; }
-        constexpr i32 EPSquare() const { return State->EPSquare; }
-        constexpr i32 CapturedPiece() const { return State->CapturedPiece; }
-        constexpr auto CastleStatus() const { return State->CastleStatus; }
+        constexpr u64 CheckSquares(i32 pt) const { return State.CheckSquares[pt]; }
+        constexpr u64 BlockingPieces(i32 pc) const { return State.BlockingPieces[pc]; }
+        constexpr u64 Pinners(i32 pc) const { return State.Pinners[pc]; }
+        constexpr i32 KingSquare(i32 pc) const { return State.KingSquares[pc]; }
+        constexpr u64 Checkers() const { return State.Checkers; }
+        constexpr u64 Hash() const { return State.Hash; }
+        constexpr u64 PawnHash() const { return State.PawnHash; }
+        constexpr u64 NonPawnHash(i32 pc) const { return State.NonPawnHash[pc]; }
+        constexpr i32 HalfmoveClock() const { return State.HalfmoveClock; }
+        constexpr i32 EPSquare() const { return State.EPSquare; }
+        constexpr i32 CapturedPiece() const { return State.CapturedPiece; }
+        constexpr auto CastleStatus() const { return State.CastleStatus; }
 
         constexpr auto CurrAccumulator() { return Accumulators.Head(); }
         constexpr auto NextAccumulator() { return Accumulators.Next(); }
@@ -59,7 +57,7 @@ namespace Horsie {
         constexpr i32 CastlingRookSquare(CastlingStatus cr) const { return CastlingRookSquares[static_cast<i32>(cr)]; }
         constexpr u64 CastlingRookPath(CastlingStatus cr) const { return CastlingRookPaths[static_cast<i32>(cr)]; }
 
-        constexpr bool HasCastlingRight(CastlingStatus cr) const { return ((State->CastleStatus & cr) != CastlingStatus::None); }
+        constexpr bool HasCastlingRight(CastlingStatus cr) const { return ((State.CastleStatus & cr) != CastlingStatus::None); }
         constexpr bool CastlingImpeded(u64 boardOcc, CastlingStatus cr) const { return (boardOcc & CastlingRookPath(cr)); }
         constexpr bool HasCastlingRook(u64 ourOcc, CastlingStatus cr) const { return (bb.Pieces[ROOK] & SquareBB(CastlingRookSquare(cr)) & ourOcc); }
         constexpr bool HasNonPawnMaterial(i32 pc) const { return (((bb.Occupancy ^ bb.Pieces[PAWN] ^ bb.Pieces[KING]) & bb.Colors[pc])); }
@@ -67,8 +65,8 @@ namespace Horsie {
         constexpr bool IsCapture(Move m) const { return bb.GetPieceAtIndex(m.To()) != Piece::NONE && !m.IsCastle(); }
         constexpr bool IsNoisy(Move m) const { return IsCapture(m) || m.IsEnPassant(); }
 
-        void RemoveCastling(CastlingStatus cr) const;
-        void UpdateHash(i32 pc, i32 pt, i32 sq) const;
+        void RemoveCastling(CastlingStatus cr);
+        void UpdateHash(i32 pc, i32 pt, i32 sq);
         constexpr CastlingStatus GetCastlingForRook(i32 sq) const;
         Move TryFindMove(const std::string& moveStr, bool& found) const;
 
@@ -113,12 +111,8 @@ namespace Horsie {
             return bb.ThreatsBy<pt>(pc);
         }
 
-
     private:
-        static constexpr i32 StateStackSize = 1024; 
-        
-        //NNUE::Accumulator* _accumulatorBlock;
-        StateInfo* StateBlock;
+        Util::List<StateInfo, 1024> States{};
         std::vector<u64> Hashes{};
 
     };

--- a/src/position.h
+++ b/src/position.h
@@ -128,6 +128,7 @@ namespace Horsie {
         
         NNUE::Accumulator* _accumulatorBlock;
         StateInfo* _stateBlock;
+        std::vector<u64> Hashes{};
 
         StateInfo* _SentinelStart;
         StateInfo* _SentinelEnd;

--- a/src/position.h
+++ b/src/position.h
@@ -21,7 +21,6 @@ namespace Horsie {
         Bitboard bb;
         Color ToMove;
         i32 FullMoves;
-        i32 GamePly;
 
         i32 CastlingRookSquares[static_cast<i32>(CastlingStatus::All)];
         u64 CastlingRookPaths[static_cast<i32>(CastlingStatus::All)];
@@ -131,7 +130,6 @@ namespace Horsie {
         std::vector<u64> Hashes{};
 
         StateInfo* _SentinelStart;
-        StateInfo* _SentinelEnd;
     };
 
     std::ostream& operator<<(std::ostream& os, const Position& pos);

--- a/src/position.h
+++ b/src/position.h
@@ -94,9 +94,9 @@ namespace Horsie {
         bool IsLegal(Move move) const;
         bool IsLegal(Move move, i32 ourKing, i32 theirKing, u64 pinnedPieces) const;
 
-        bool IsDraw() const;
+        bool IsDraw(i16 ply = 0) const;
         bool IsInsufficientMaterial() const;
-        bool IsThreefoldRepetition() const;
+        bool IsThreefoldRepetition(i16 ply) const;
         bool IsFiftyMoveDraw() const;
         bool HasLegalMoves() const;
 

--- a/src/position.h
+++ b/src/position.h
@@ -94,9 +94,6 @@ namespace Horsie {
         bool IsLegal(Move move, i32 ourKing, i32 theirKing, u64 pinnedPieces) const;
 
         bool IsDraw(i16 ply = 0) const;
-        bool IsInsufficientMaterial() const;
-        bool IsThreefoldRepetition(i16 ply) const;
-        bool IsFiftyMoveDraw() const;
         bool HasLegalMoves() const;
 
         i32 MaterialCount() const;
@@ -114,13 +111,6 @@ namespace Horsie {
             return bb.ThreatsBy<pt>(pc);
         }
 
-        inline i32 PawnCorrectionIndex(i32 pc) const {
-            return (pc * 16384) + static_cast<i32>(PawnHash() % 16384);
-        }
-
-        inline i32 NonPawnCorrectionIndex(i32 pc, i32 side) const {
-            return (pc * 16384) + static_cast<i32>(NonPawnHash(side) % 16384);
-        }
 
     private:
         static constexpr i32 StateStackSize = 1024; 

--- a/src/position.h
+++ b/src/position.h
@@ -15,22 +15,22 @@ namespace Horsie {
         ~Position();
         void LoadFromFEN(const std::string& fen);
 
+        NNUE::AccumulatorStack Accumulators;
         NNUE::BucketCache CachedBuckets;
         StateInfo* State;
 
-        Bitboard bb;
-        Color ToMove;
-        i32 FullMoves;
+        Bitboard bb{};
+        Color ToMove{};
+        i32 FullMoves{};
 
-        i32 CastlingRookSquares[static_cast<i32>(CastlingStatus::All)];
-        u64 CastlingRookPaths[static_cast<i32>(CastlingStatus::All)];
+        i32 CastlingRookSquares[static_cast<i32>(CastlingStatus::All)]{};
+        u64 CastlingRookPaths[static_cast<i32>(CastlingStatus::All)]{};
 
-        bool UpdateNN;
-        bool IsChess960;
+        bool IsChess960{};
 
         constexpr bool InCheck()       const { return State->Checkers != 0; }
         constexpr bool InDoubleCheck() const { return MoreThanOne(State->Checkers); }
-        constexpr StateInfo* StartingState() const { return _SentinelStart; }
+        constexpr StateInfo* StartingState() const { return StateBlock; }
         constexpr StateInfo* PreviousState() const { return State - 1; }
         constexpr StateInfo* NextState() const { return State + 1; }
 
@@ -46,10 +46,9 @@ namespace Horsie {
         constexpr i32 EPSquare() const { return State->EPSquare; }
         constexpr i32 CapturedPiece() const { return State->CapturedPiece; }
         constexpr auto CastleStatus() const { return State->CastleStatus; }
-        constexpr auto accumulator() const { return State->accumulator; }
 
-        constexpr auto CurrAccumulator() const { return State->accumulator; }
-        constexpr auto NextAccumulator() const { return NextState()->accumulator; }
+        constexpr auto CurrAccumulator() { return Accumulators.Head(); }
+        constexpr auto NextAccumulator() { return Accumulators.Next(); }
 
         constexpr bool GivesCheck(i32 pt, i32 sq) const { return (CheckSquares(pt) & SquareBB(sq)); }
 
@@ -77,7 +76,10 @@ namespace Horsie {
         void MakeMove(Move move);
         void MakeMove(Move move);
 
+        template<bool UpdateNN>
         void UnmakeMove(Move move);
+        void UnmakeMove(Move move);
+
         void MakeNullMove();
         void UnmakeNullMove();
 
@@ -115,11 +117,10 @@ namespace Horsie {
     private:
         static constexpr i32 StateStackSize = 1024; 
         
-        NNUE::Accumulator* _accumulatorBlock;
-        StateInfo* _stateBlock;
+        //NNUE::Accumulator* _accumulatorBlock;
+        StateInfo* StateBlock;
         std::vector<u64> Hashes{};
 
-        StateInfo* _SentinelStart;
     };
 
     std::ostream& operator<<(std::ostream& os, const Position& pos);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -252,7 +252,7 @@ namespace Horsie {
         }
 
         if (!isRoot) {
-            if (pos.IsDraw()) {
+            if (pos.IsDraw(ss->Ply)) {
                 return MakeDrawScore(Nodes);
             }
 
@@ -807,7 +807,7 @@ namespace Horsie {
             SelDepth = std::max(SelDepth, ss->Ply + 1);
         }
 
-        if (pos.IsDraw()) {
+        if (pos.IsDraw(ss->Ply)) {
             return ScoreDraw;
         }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -494,8 +494,9 @@ namespace Horsie {
                 continue;
             }
 
-            if (isRoot && MultiPV != 1) {
+            if (isRoot) {
                 //  If this move is ordered before PVIndex, it's already been searched.
+                //  Also handles searchmoves, ensuring the current move is in the list.
                 if (std::count(RootMoves.begin() + PVIndex, RootMoves.end(), m) == 0)
                     continue;
             }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1007,7 +1007,7 @@ namespace Horsie {
     }
 
     i16 SearchThread::AdjustEval(Position& pos, i32 us, i16 rawEval) const {
-        rawEval = static_cast<i16>(rawEval * (200 - pos.State->HalfmoveClock) / 200);
+        rawEval = static_cast<i16>(rawEval * (200 - pos.HalfmoveClock()) / 200);
 
         const auto pawn = History.PawnCorrection[us][pos.PawnHash() % 16384] / CorrectionGrain;
         const auto nonPawnW = History.NonPawnCorrection[us][pos.NonPawnHash(Color::WHITE) % 16384] / CorrectionGrain;

--- a/src/search.h
+++ b/src/search.h
@@ -114,9 +114,9 @@ namespace Horsie {
         };
 
         struct ThreadSetup {
-            std::string StartFEN;
-            std::vector<Move> SetupMoves;
-            std::vector<Move> UCISearchMoves;
+            std::string StartFEN{};
+            std::vector<Move> SetupMoves{};
+            std::vector<Move> UCISearchMoves{};
 
             ThreadSetup(std::vector<Move> setupMoves) : ThreadSetup(InitialFEN, setupMoves, {}) {}
             ThreadSetup(std::string_view fen = InitialFEN) : ThreadSetup(fen, {}, {}) {}

--- a/src/types.h
+++ b/src/types.h
@@ -23,7 +23,7 @@
 namespace Horsie {
 
     constexpr auto InitialFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-    constexpr auto EngVersion = "1.0.21";
+    constexpr auto EngVersion = "1.0.22";
 
     constexpr u64 FileABB = 0x0101010101010101ULL;
     constexpr u64 FileBBB = FileABB << 1;

--- a/src/types.h
+++ b/src/types.h
@@ -225,25 +225,20 @@ namespace Horsie {
         struct Accumulator; 
     }
 
-    struct alignas(32) StateInfo {
-    public:
-
+    struct StateInfo {
         u64 CheckSquares[PIECE_NB];
         u64 BlockingPieces[2];
         u64 Pinners[2];
-        i32 KingSquares[2];
-        u64 Checkers = 0;
+        u64 NonPawnHash[2];
         u64 Hash = 0;
         u64 PawnHash = 0;
-        u64 NonPawnHash[2];
+        u64 Checkers = 0;
+        i32 KingSquares[2];
         i32 HalfmoveClock = 0;
         i32 EPSquare = EP_NONE;
         i32 CapturedPiece = Piece::NONE;
         i32 PliesFromNull = 0;
         CastlingStatus CastleStatus = CastlingStatus::None;
-
-        NNUE::Accumulator* accumulator;
     };
 
-    constexpr static i32 StateCopySize = sizeof(StateInfo) - sizeof(u64);
 }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -148,8 +148,20 @@ namespace Horsie::UCI {
         limits.MoveTime = 0;
         limits.Increment = 0;
 
-        while (is >> token)
-            if ((pos.ToMove == WHITE && token == "wtime") || (pos.ToMove == BLACK && token == "btime"))
+        setup.UCISearchMoves.clear();
+
+        while (is >> token) {
+            if (token == "searchmoves") {
+                while (is >> token) {
+                    bool found = false;
+                    Move m = pos.TryFindMove(token, found);
+                    
+                    if (found)
+                        setup.UCISearchMoves.push_back(m);
+                }
+            }
+
+            else if ((pos.ToMove == WHITE && token == "wtime") || (pos.ToMove == BLACK && token == "btime"))
                 is >> limits.PlayerTime;
 
             else if ((pos.ToMove == WHITE && token == "winc") || (pos.ToMove == BLACK && token == "binc"))
@@ -166,6 +178,7 @@ namespace Horsie::UCI {
 
             else if (token == "movestogo")
                 is >> limits.MovesToGo;
+        }
 
         return limits;
     }
@@ -251,6 +264,7 @@ namespace Horsie::UCI {
 
         setup.StartFEN = fen;
         setup.SetupMoves.clear();
+        setup.UCISearchMoves.clear();
 
         while (is >> token) {
             bool found = false;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -276,7 +276,7 @@ namespace Horsie::UCI {
         SearchLimits limits = ParseGoParameters(is);
         thread->SoftTimeLimit = limits.SetTimeLimits();
 
-        SearchPool->StartSearch(pos, limits);
+        SearchPool->StartSearch(pos, limits, setup);
     }
 
     void UCIClient::HandleStopCommand() {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -370,8 +370,10 @@ namespace Horsie::UCI {
         
         bool found{};
         Move m = pos.TryFindMove(moveStr, found);
-        if (found)
-            pos.MakeMove<true>(m);
+        if (found) {
+            pos.MakeMove(m);
+            setup.SetupMoves.push_back(m);
+        }
     }
 
 

--- a/src/util/list.h
+++ b/src/util/list.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "../defs.h"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+
+namespace Horsie::Util {
+    template <class T, size_t Capacity>
+    class List {
+    public:
+        List() : Count(0) { }
+
+        constexpr auto Size() const { return Count; }
+        constexpr bool Empty() const { return Count == 0; }
+        constexpr void Clear() { Count = 0; }
+
+        constexpr T& operator[](int i) {
+            assert(i >= 0 && i < Count);
+            return Items[i];
+        }
+
+        constexpr T operator[](int i) const {
+            assert(i >= 0 && i < Count);
+            return Items[i];
+        }
+
+        constexpr void Add(const T& object) {
+            assert(Count < Capacity);
+            Items[Count++] = object;
+        }
+
+        constexpr T& RemoveLast() {
+            assert(Count > 0);
+            return Items[--Count];
+        }
+
+        constexpr T& Last() { return Items[Count - 1]; }
+
+        constexpr auto& Raw() { return Items; }
+
+    private:
+        std::array<T, Capacity> Items;
+        i32 Count = 0;
+    };
+}


### PR DESCRIPTION
Up until now, search threads were accidentally not actually given the moves made in `position startpos moves ...` (only the resulting board FEN) and as a result would be [blind to threefold repetitions](https://tcec-chess.com/#div=cat3p&game=17&season=28).

Fixing this particular bug caused major issues:
```
Elo   | -12.74 +- 6.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 2374 W: 477 L: 564 D: 1333
Penta | [5, 319, 623, 238, 2]
```
https://somelizard.pythonanywhere.com/test/2539/


So board states were rewritten to be less finicky, mainly by removing the accumulator pointer from them and storing them in a separate list. This means null moves no longer need to be special cased, a previous state can be copied entirely into a current one without having to ensure the accumulator pointer isn't overwritten, and there's less pointer usage in general.

The final result:
```
Elo   | -0.00 +- 2.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 28438 W: 6455 L: 6455 D: 15528
Penta | [40, 3350, 7426, 3376, 27]
```
https://somelizard.pythonanywhere.com/test/2571/