### PR TITLE
Refactor(tm) newDepth to include the -1

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -617,7 +617,7 @@ namespace Horsie {
                 (ss + 1)->PVLength = 0;
             }
 
-            i32 newDepth = depth + extend;
+            i32 newDepth = depth - 1 + extend;
 
             if (depth >= 2
                 && legalMoves >= 2
@@ -637,38 +637,35 @@ namespace Horsie {
 
                 R -= (histScore / (isCapture ? LMRCaptureDiv : LMRQuietDiv));
 
-                R = std::max(1, std::min(R, newDepth));
-                i32 reducedDepth = (newDepth - R);
+                const auto reduced = std::max(0, std::min(newDepth - R, newDepth));
+                
+                score = -Negamax<NonPVNode>(pos, ss + 1, -alpha - 1, -alpha, reduced, true);
 
-                score = -Negamax<NonPVNode>(pos, ss + 1, -alpha - 1, -alpha, reducedDepth, true);
+                if (score > alpha && reduced < newDepth) {
+                    bool    deeper = score > (bestScore + DeeperMargin + 4 * newDepth);
+                    bool shallower = score < (bestScore + newDepth);
 
-                if (score > alpha && R > 1) {
-                    newDepth += (score > (bestScore + DeeperMargin + 4 * newDepth));
-                    newDepth -= (score < (bestScore + newDepth));
+                    newDepth += deeper - shallower;
 
-                    if (newDepth - 1 > reducedDepth) {
-                        score = -Negamax<NonPVNode>(pos, ss + 1, -alpha - 1, -alpha, newDepth - 1, !cutNode);
+                    if (reduced < newDepth) {
+                        score = -Negamax<NonPVNode>(pos, ss + 1, -alpha - 1, -alpha, newDepth, !cutNode);
                     }
 
-                    i32 bonus = 0;
-                    if (score <= alpha) {
-                        bonus = -StatBonus(newDepth - 1);
-                    }
-                    else if (score >= beta) {
-                        bonus = StatBonus(newDepth - 1);
-                    }
+                    i32 bonus = (score <= alpha) ? -StatBonus(newDepth)
+                              : (score >= beta)  ?  StatBonus(newDepth)
+                              :                     0;
 
                     UpdateContinuations(ss, us, ourPiece, moveTo, bonus);
                 }
             }
             else if (!isPV || legalMoves > 1) {
-                score = -Negamax<NonPVNode>(pos, ss + 1, -alpha - 1, -alpha, newDepth - 1, !cutNode);
+                score = -Negamax<NonPVNode>(pos, ss + 1, -alpha - 1, -alpha, newDepth, !cutNode);
             }
 
             if (isPV && (playedMoves == 1 || score > alpha)) {
                 (ss + 1)->PV[0] = Move::Null();
                 (ss + 1)->PVLength = 0;
-                score = -Negamax<PVNode>(pos, ss + 1, -beta, -alpha, newDepth - 1, false);
+                score = -Negamax<PVNode>(pos, ss + 1, -beta, -alpha, newDepth, false);
             }
 
             pos.UnmakeMove(m);


### PR DESCRIPTION
womp womp, my nonreg failed I can't merge it
```
Elo   | -2.37 +- 2.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 24512 W: 5478 L: 5645 D: 13389
Penta | [28, 3007, 6357, 2832, 32]
```
https://chess.n9x.co/test/3152/