### PR TITLE
Reorganize "isPV" adjustment in LMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -628,17 +628,16 @@ namespace Horsie {
                 && legalMoves >= 2
                 && !(isPV && isCapture)) {
 
+                i32 histScore = LMRHist * moveHist +
+                    LMRHistSS1 * GetContinuationEntry(ss->Ply, 1, piece, moveTo) +
+                    LMRHistSS2 * GetContinuationEntry(ss->Ply, 2, piece, moveTo) +
+                    LMRHistSS4 * GetContinuationEntry(ss->Ply, 4, piece, moveTo);
+
                 R += (!improving) * LMRNotImpCoeff;
                 R += cutNode * LMRCutNodeCoeff;
 
                 R -= ss->TTPV * LMRTTPVCoeff;
                 R -= (m == ss->KillerMove) * LMRKillerCoeff;
-
-                i32 histScore = LMRHist * moveHist +
-                                LMRHistSS1 * GetContinuationEntry(ss->Ply, 1, piece, moveTo) +
-                                LMRHistSS2 * GetContinuationEntry(ss->Ply, 2, piece, moveTo) +
-                                LMRHistSS4 * GetContinuationEntry(ss->Ply, 4, piece, moveTo);
-
                 R -= (histScore / ((isCapture ? LMRCaptureDiv : LMRQuietDiv)));
                 
                 R /= 128;
@@ -658,7 +657,7 @@ namespace Horsie {
                     }
 
                     i32 bonus = (score <= alpha) ? LMRPenalty(newDepth)
-                              : (score >= beta)  ? LMRBonus(newDepth)
+                              : (score >=  beta) ? LMRBonus(newDepth)
                               :                    0;
 
                     UpdateContinuations(ss->Ply, MakePiece(us, ourPiece), moveTo, bonus, ss->InCheck);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -632,7 +632,6 @@ namespace Horsie {
                 R += cutNode * LMRCutNodeCoeff;
 
                 R -= ss->TTPV * LMRTTPVCoeff;
-                R -= isPV * LMRPVCoeff;
                 R -= (m == ss->KillerMove) * LMRKillerCoeff;
 
                 i32 histScore = LMRHist * moveHist +
@@ -644,7 +643,7 @@ namespace Horsie {
                 
                 R /= 128;
 
-                const auto reduced = std::max(0, std::min(newDepth - R, newDepth));
+                const auto reduced = std::max(0, std::min(newDepth - R, newDepth)) + isPV;
                 
                 score = -Negamax<NonPVNode>(pos, ss + 1, -alpha - 1, -alpha, reduced, true);
 

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -63,7 +63,6 @@ namespace Horsie {
     UCI_OPTION(LMRNotImpCoeff, 119)
     UCI_OPTION(LMRCutNodeCoeff, 280)
     UCI_OPTION(LMRTTPVCoeff, 124)
-    UCI_OPTION(LMRPVCoeff, 133)
     UCI_OPTION(LMRKillerCoeff, 129)
 
     UCI_OPTION(LMRHist, 189)

--- a/src/types.h
+++ b/src/types.h
@@ -24,7 +24,7 @@
 namespace Horsie {
 
     constexpr auto InitialFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-    constexpr auto EngVersion = "1.1.4";
+    constexpr auto EngVersion = "1.1.5";
 
     constexpr u64 FileABB = 0x0101010101010101ULL;
     constexpr u64 FileBBB = FileABB << 1;


### PR DESCRIPTION
```
Elo   | 3.62 +- 2.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 20148 W: 4678 L: 4468 D: 11002
Penta | [17, 2310, 5225, 2490, 32]
```
https://somelizard.pythonanywhere.com/test/2742/

```
Elo   | 3.19 +- 3.85 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 7288 W: 1665 L: 1598 D: 4025
Penta | [2, 806, 1961, 873, 2]
```
https://somelizard.pythonanywhere.com/test/2743/