### PR TITLE
Hindsight extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -336,12 +336,10 @@ namespace Horsie {
         if (!isPV
             && !doSkip
             && !ss->InCheck
-            && depth >= 2
-            && (ss - 1)->Reduction >= 1
-            && (ss - 1)->StaticEval != ScoreNone
-            && (ss->StaticEval + (ss - 1)->StaticEval) >= 140) {
+            && (ss - 1)->Reduction >= 2
+            && (ss->StaticEval + (ss - 1)->StaticEval) < 0) {
 
-            depth -= 1;
+            depth += 1;
         }
 
         if (UseRFP

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -333,6 +333,16 @@ namespace Horsie {
             UpdateMainHistory(Not(us), priorMove, bonus);
         }
 
+        if (!isPV
+            && !doSkip
+            && !ss->InCheck
+            && depth >= 2
+            && (ss - 1)->Reduction >= 1
+            && (ss - 1)->StaticEval != ScoreNone
+            && (ss->StaticEval + (ss - 1)->StaticEval) >= 140) {
+
+            depth -= 1;
+        }
 
         if (UseRFP
             && !ss->TTPV
@@ -644,7 +654,9 @@ namespace Horsie {
 
                 const auto reduced = std::max(0, std::min(newDepth - R, newDepth)) + isPV;
                 
+                ss->Reduction = static_cast<i16>(newDepth - reduced);
                 score = -Negamax<NonPVNode>(pos, ss + 1, -alpha - 1, -alpha, reduced, true);
+                ss->Reduction = 0;
 
                 if (score > alpha && reduced < newDepth) {
                     bool    deeper = score > (bestScore + DeeperMargin + 4 * newDepth);

--- a/src/search.h
+++ b/src/search.h
@@ -62,6 +62,7 @@ namespace Horsie {
             i16 DoubleExtensions;
             i16 Ply;
             i16 StaticEval;
+            i16 Reduction;
             Move KillerMove;
             Move Skip;
             bool InCheck;
@@ -73,7 +74,7 @@ namespace Horsie {
             void Clear() {
                 Skip = KillerMove = Move::Null();
 
-                Ply = 0;
+                Ply = Reduction = 0;
                 DoubleExtensions = 0;
                 StaticEval = ScoreNone;
 

--- a/src/types.h
+++ b/src/types.h
@@ -24,7 +24,7 @@
 namespace Horsie {
 
     constexpr auto InitialFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-    constexpr auto EngVersion = "1.1.6";
+    constexpr auto EngVersion = "1.1.7";
 
     constexpr u64 FileABB = 0x0101010101010101ULL;
     constexpr u64 FileBBB = FileABB << 1;


### PR DESCRIPTION
```
Elo   | 2.25 +- 1.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 38838 W: 9045 L: 8794 D: 20999
Penta | [36, 4512, 10102, 4703, 66]
```
https://somelizard.pythonanywhere.com/test/2757/

```
Elo   | 3.09 +- 2.60 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 1.95 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16072 W: 3793 L: 3650 D: 8629
Penta | [7, 1792, 4291, 1943, 3]
```
https://somelizard.pythonanywhere.com/test/2758/