### PR TITLE
Reduce more for TTPV nodes that would fail low

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -643,6 +643,7 @@ namespace Horsie {
 
                 R += (!improving) * LMRNotImpCoeff;
                 R += cutNode * LMRCutNodeCoeff;
+                R += (ss->TTPV && ttScore != ScoreNone && ttScore <= alpha) * 128;
 
                 R -= ss->TTPV * LMRTTPVCoeff;
                 R -= (m == ss->KillerMove) * LMRKillerCoeff;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -643,7 +643,7 @@ namespace Horsie {
 
                 R += (!improving) * LMRNotImpCoeff;
                 R += cutNode * LMRCutNodeCoeff;
-                R += (ss->TTPV && ttScore != ScoreNone && ttScore <= alpha) * 128;
+                R += (ss->TTPV && ttScore != ScoreNone && ttScore <= alpha) * LMRTTPVFailLowCoeff;
 
                 R -= ss->TTPV * LMRTTPVCoeff;
                 R -= (m == ss->KillerMove) * LMRKillerCoeff;

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -63,6 +63,7 @@ namespace Horsie {
     UCI_OPTION(LMRNotImpCoeff, 119)
     UCI_OPTION(LMRCutNodeCoeff, 280)
     UCI_OPTION(LMRTTPVCoeff, 124)
+    UCI_OPTION(LMRTTPVFailLowCoeff, 128)
     UCI_OPTION(LMRKillerCoeff, 129)
 
     UCI_OPTION(LMRHist, 189)

--- a/src/types.h
+++ b/src/types.h
@@ -24,7 +24,7 @@
 namespace Horsie {
 
     constexpr auto InitialFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-    constexpr auto EngVersion = "1.1.7";
+    constexpr auto EngVersion = "1.1.8";
 
     constexpr u64 FileABB = 0x0101010101010101ULL;
     constexpr u64 FileBBB = FileABB << 1;


### PR DESCRIPTION
```
Elo   | 2.46 +- 1.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 33720 W: 7879 L: 7640 D: 18201
Penta | [34, 3897, 8771, 4112, 46]
```
https://somelizard.pythonanywhere.com/test/2760/

```
Elo   | 1.56 +- 3.07 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.49 (-2.25, 2.89) [0.00, 3.00]
Games | N: 11840 W: 2792 L: 2739 D: 6309
Penta | [4, 1379, 3100, 1434, 3]
```
https://somelizard.pythonanywhere.com/test/2764/